### PR TITLE
Feature#1 global exception handler

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/CommonException.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/CommonException.java
@@ -1,0 +1,22 @@
+package com.swmarastro.mykkumiserver.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class CommonException extends RuntimeException{
+
+    private final String errorCodeName;
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String detail;
+
+    public CommonException(ErrorCode errorCode, String message, String detail) {
+        this.errorCodeName = errorCode.getErrorCodeName();
+        this.httpStatus = errorCode.getHttpStatus();
+        this.message = message;
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.swmarastro.mykkumiserver.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    ;
+
+    private final HttpStatus httpStatus;
+
+    public String getErrorCodeName() {
+        return this.name();
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.swmarastro.mykkumiserver.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private String errorCode;
+    private String message;
+    private String detail;
+
+    public static ErrorResponse from(CommonException e) {
+        return ErrorResponse.builder()
+                .errorCode(e.getErrorCodeName())
+                .message(e.getMessage())
+                .detail(e.getDetail())
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.swmarastro.mykkumiserver.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(value = CommonException.class)
+    public ResponseEntity<ErrorResponse> handle(CommonException e) {
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e));
+    }
+}


### PR DESCRIPTION
## 구현내용
### 1. ErrorCode 구현
자체 에러 코드와 매핑되는 HttpStatus 함께 관리
아래는 예시입니다.
```java
HELLO_ERROR_ONE(HttpStatus.BadRequest)
```

### 2. GlobalExceptionHandler 구현
아래와 같이 예외 발생시키면 GlobalExceptionHandler가 잡아서 클라이언트에게 에러 메시지를 전송합니다.
- 예외 발생시키기
```java
throw new CommonException(ErrorCode.HELLO_ERROR_ONE, "에러메시지", "상세 에러메시지");
```
- 클라이언트에게 전송되는 json 메시지
```text
{
    "errorCode": "HELLO_ERROR_ONE",
    "message": "에러메시지",
    "detail": "상세 에러메시지"
}
```


## 고민사항
### 1. ErrorCode에 설명까지 상세하게 넣는 것이 좋을지
기존 생각은 ErrorCode 파일에 상세 설명까지 전부 넣어놓으려고 했습니다.
멘토님께 질문한 결과,
1. 하나의 에러코드에도 여러 상황의 상세 설명이 필요할 수 있다.
2. 글로벌 서비스의 경우 다국어 처리


위와 같은 이유로 ErrorCode에는 HELLO_ERROR_ONE과 같은 코드와 HttpStatus만 넣어서 저장해놓고, 예외를 던지는 상황에서 설명을 붙여주기로 결정했습니다.