### PR TITLE
Feat#4 dev cicd

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,0 +1,92 @@
+# workflow의 이름
+name: CI/CD
+
+# 해당 workflow가 언제 실행될 것인지에 대한 트리거를 지정
+on:
+  push:
+    branches: [ develop ] # develop branch로 push 될 때 실행됩니다.
+
+# 해당 yml 내에서 사용할 key - value
+env:
+  S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+  PROJECT_NAME: ${{ secrets.AWS_CODEDEPLOY_PROJECT_NAME }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_CODEDEPLOY_APPLICATION_NAME: ${{ secrets.AWS_CODEDEPLOY_APPLICATION_NAME }}
+  AWS_CODEDEPLOY_GROUP_NAME: ${{ secrets.AWS_CODEDEPLOY_GROUP_NAME }}
+
+# workflow는 한개 이상의 job을 가지며, 각 job은 여러 step에 따라 단계를 나눌 수 있습니다.
+jobs:
+  build:
+    name: CI
+    # 해당 jobs에서 아래의 steps들이 어떠한 환경에서 실행될 것인지를 지정합니다.
+    runs-on: ubuntu-latest
+
+    steps:
+      # 작업에서 액세스할 수 있도록 $GITHUB_WORKSPACE에서 저장소를 체크아웃합니다.
+      - uses: actions/checkout@v2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        shell: bash
+
+      - name: Build with Gradle
+        run: ./gradlew build
+        shell: bash
+
+  deploy:
+    name: CD
+    needs: build
+    # 해당 jobs에서 아래의 steps들이 어떠한 환경에서 실행될 것인지를 지정합니다.
+    runs-on: ubuntu-latest
+
+    steps:
+      # 작업에서 액세스할 수 있도록 $GITHUB_WORKSPACE에서 저장소를 체크아웃합니다.
+      - uses: actions/checkout@v2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        shell: bash
+
+      - name: Build with Gradle
+        run: ./gradlew build
+        shell: bash
+
+      - name: Make zip file
+        run: zip -r ./$GITHUB_SHA.zip .
+        shell: bash
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # script files 복사
+      - name: Copy script
+        run: cp ./scripts/*.sh ./deploy
+
+      # S3에 업로드
+      - name: Upload to S3
+        run: aws s3 cp --region $AWS_REGION ./$GITHUB_SHA.zip s3://$S3_BUCKET_NAME/$PROJECT_NAME/$GITHUB_SHA.zip
+
+      # Deploy
+      - name: Deploy
+        run: |
+          aws deploy create-deployment \
+          --application-name $AWS_CODEDEPLOY_APPLICATION_NAME \
+          --deployment-config-name CodeDeployDefault.AllAtOnce \
+          --deployment-group-name $AWS_CODEDEPLOY_GROUP_NAME \
+          --file-exists-behavior OVERWRITE \
+          --s3-location bucket=$S3_BUCKET_NAME,bundleType=zip,key=$PROJECT_NAME/$GITHUB_SHA.zip \
+          --region $AWS_REGION \

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,20 @@
+version: 0.0
+os: linux
+# S3에 있는 zip 파일이 EC2에 배포될 위치를 지정
+files:
+  - source: / # CodeDeploy에서 전달해 준 파일 중 destination으로 이동시킬 대상을 루트로 지정(전체파일)
+    destination: /home/ec2-user/action/ # source에서 지정된 파일을 받을 위치, 이후 jar를 실행하는 등은 destination에서 옮긴 파일들로 진행
+    overwrite: yes
+
+permissions: # CodeDeploy에서 EC2서버로 넘겨준 파일들을 모두 ec2-user권한을 갖도록 합니다.
+  - object: /
+    pattern: "**"
+    owner: ec2-user
+    group: ec2-user
+
+# ApplicationStart 단계에서 deploy.sh를 실행시키도록 합
+hooks: # CodeDeploy배포 단계에서 실행할 명령어를 지정합니다.
+  ApplicationStart: # deploy.sh를 ec2-user권한으로 실행합니다.
+    - location: scripts/deploy.sh
+      timeout: 60 # 스크립트 실행 60초 이상 수행되면 실패가 됩니다.
+      runas: ec2-user

--- a/build.gradle
+++ b/build.gradle
@@ -33,3 +33,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+tasks.named('jar') {
+    enabled = false
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+BUILD_JAR=$(ls /home/ec2-user/action/build/libs/*.jar)
+JAR_NAME=$(basename $BUILD_JAR)
+echo "> build 파일명: $JAR_NAME" >> /home/ec2-user/action/deploy.log
+
+echo "> build 파일 복사" >> /home/ec2-user/action/deploy.log
+DEPLOY_PATH=/home/ec2-user/action/
+cp $BUILD_JAR $DEPLOY_PATH
+
+echo "> 현재 실행중인 애플리케이션 pid 확인" >> /home/ec2-user/action/deploy.log
+
+killall java
+sleep 5
+
+DEPLOY_JAR=$DEPLOY_PATH$JAR_NAME
+echo "> DEPLOY_JAR 배포"    >> /home/ec2-user/action/deploy.log
+nohup java -jar $DEPLOY_JAR >> /home/ec2-user/deploy.log 2>/home/ec2-user/action/deploy_err.log &


### PR DESCRIPTION
## 구현내용
### 1. dev 환경 ci/cd
develop 환경에 push될때, 개발 환경에 배포되도록 했습니다.
![스크린샷 2024-06-18 오후 5 56 13](https://github.com/SW-Marastro/Mykkumi-BE/assets/59831262/456e8288-5bce-4333-b7ca-e42e670bfa28)

1. develop 브랜치로 코드를 Push 하면 GitHub Actions이 자동으로 실행되어 CI 작업을 수행합니다.
2. 코드에 문제가 없다면 빌드 작업을 통해 jar파일이 생성되고 사전에 작성한 배포 스크립트 파일과 함께 AWS의 스토리지 서비스인 S3에게 전달되어 저장되게 됩니다.
3. S3에 성공적으로 저장됐다면 EC2에 설치한 CodeDeply Agent가 S3에 저장된 프로젝트 파일을 가져와서 내려받습니다.
4. 그 후, 배포 스크립트 파일을 읽어 들여서 프로젝트 실행을 시작합니다.

## 고민사항
### 1. plain jar 파일 문제
ec2 서버에는 jar 파일 등이 정상적으로 생겼으나, 실행되지 않는 문제가 있었습니다.
*.jar 코드를 실행시키다보니 plain jar가 실행됐던 것이 문제였습니다.
plain jar는 java -jar로 실행시킬 수 없어 제대로 실행되지 않았었습니다.
현재 필요가 없다고 생각하여 plain jar가 생기지 않도록 코드를 수정했습니다.
build.gradle 파일에 아래와 같은 코드를 추가했습니다.
```java
tasks.named('jar') {
    enabled = false
}
```