### PR TITLE
KKUMI-16 get home banners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,16 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.orm:hibernate-core:6.2.3.Final'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //secrets manager
+    implementation "io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
@@ -5,9 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class MykkumiServerApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(MykkumiServerApplication.class, args);
     }
-
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -11,5 +12,5 @@ public class Banner {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "banner_id")
     private Long id;
-    private String image_url;
+    private String imageUrl;
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
@@ -1,6 +1,5 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
@@ -1,0 +1,15 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Banner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "banner_id")
+    private Long id;
+    private String image_url;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
@@ -1,0 +1,21 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/banners")
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    public ResponseEntity<BannersResponse> getBanners() {
+        return ResponseEntity.ok(bannerService.getAllBanners());
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
@@ -1,12 +1,15 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
 import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "banners", description = "홈화면 상단 배너 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/banners")
@@ -15,6 +18,7 @@ public class BannerController {
     private final BannerService bannerService;
 
     @GetMapping
+    @Operation(summary = "상단 배너 전체 불러오기", description = "배너id와 배너 이미지 url을 list로 불러옵니다.")
     public ResponseEntity<BannersResponse> getBanners() {
         return ResponseEntity.ok(bannerService.getAllBanners());
     }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerRepository.java
@@ -1,0 +1,6 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
@@ -1,0 +1,19 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    public BannersResponse getAllBanners() {
+        return BannersResponse.builder()
+                .banners(bannerRepository.findAll())
+                .build();
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
@@ -1,11 +1,13 @@
 package com.swmarastro.mykkumiserver.domain.banner.dto;
 
 import com.swmarastro.mykkumiserver.domain.banner.Banner;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
+@Schema(description = "홈화면 상단 배너 전체 List DTO")
 @Getter
 @Builder
 public class BannersResponse {

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
@@ -1,0 +1,14 @@
+package com.swmarastro.mykkumiserver.domain.banner.dto;
+
+import com.swmarastro.mykkumiserver.domain.banner.Banner;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BannersResponse {
+
+    List<Banner> banners;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,21 @@
 spring:
   application:
     name: mykkumi-server
+  config:
+    import: 'aws-secretsmanager:dev/mykkumi/mysql'
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${db_host}:${db_port}/dbMykkumiDev?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${db_username}
+    password: ${db_password}
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 server:
   port: 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,9 @@ spring:
   application:
     name: mykkumi-server
   config:
-    import: 'aws-secretsmanager:dev/mykkumi/mysql'
+    import:
+      - 'aws-secretsmanager:dev/mykkumi/mysql'
+      - 'aws-secretsmanager:dev/mykkumi/s3'
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${db_host}:${db_port}/dbMykkumiDev?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
@@ -11,13 +13,28 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
 server:
   port: 8080
+
+cloud:
+  aws:
+    s3:
+      bucket: ${s3_bucket_name}
+    credentials:
+      access-key: ${s3_access_key}
+      secret-key: ${s3_secret_key}
+    region:
+      auto: false
+      static: ${region}
+      use-default-aws-region-chain: true
+    stack:
+      auto: false
 
 springdoc:
   packages-to-scan: com.swmarastro.mykkumiserver


### PR DESCRIPTION
## 구현내용
### 1. 배너 전체 호출 api
배너 전체 호출 api를 구현했습니다.
홈화면 상단의 배너 list를 보내줍니다.

## 고민사항
### 1. AWS RDS 키 보관
RDS를 사용하며 액세스 키, 시크릿 키 등을 어떻게 보관할지 고민했습니다.
이전에는 .yml 파일을 따로 만들어 .gitignore 파일에 넣어 깃허브에 올라가지 않도록 관리했습니다.
이번에는 AWS의 secrets manager를 사용했습니다. 
중요한 키를 알아서 암호화하여 보관해주고 실수로 업로드할 가능성을 줄여줬습니다.
또 모든 중요한 키를 한번에 관리할 수 있어 편리했습니다.