### PR TITLE
KKUMI-16 get banners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,16 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.orm:hibernate-core:6.2.3.Final'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //secrets manager
+    implementation "io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
@@ -5,9 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class MykkumiServerApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(MykkumiServerApplication.class, args);
     }
-
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -11,5 +12,5 @@ public class Banner {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "banner_id")
     private Long id;
-    private String image_url;
+    private String imageUrl;
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
@@ -1,6 +1,5 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
@@ -1,0 +1,15 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Banner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "banner_id")
+    private Long id;
+    private String image_url;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/Banner.java
@@ -12,4 +12,5 @@ public class Banner {
     @Column(name = "banner_id")
     private Long id;
     private String imageUrl;
+    private String detailImageUrl;
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
@@ -1,6 +1,6 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
-import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannerListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class BannerController {
 
     @GetMapping
     @Operation(summary = "상단 배너 전체 불러오기", description = "배너id와 배너 이미지 url을 list로 불러옵니다.")
-    public ResponseEntity<BannersResponse> getBanners() {
+    public ResponseEntity<BannerListResponse> getBanners() {
         return ResponseEntity.ok(bannerService.getAllBanners());
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
@@ -1,0 +1,21 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/banners")
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @GetMapping
+    public ResponseEntity<BannersResponse> getBanners() {
+        return ResponseEntity.ok(bannerService.getAllBanners());
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
@@ -1,11 +1,13 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannerDto;
 import com.swmarastro.mykkumiserver.domain.banner.dto.BannerListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +23,11 @@ public class BannerController {
     @Operation(summary = "상단 배너 전체 불러오기", description = "배너id와 배너 이미지 url을 list로 불러옵니다.")
     public ResponseEntity<BannerListResponse> getBanners() {
         return ResponseEntity.ok(bannerService.getAllBanners());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "배너 id로 배너 상세 불러오기", description = "배너 id로 배너 상세 이미지를 불러옵니다.")
+    public ResponseEntity<BannerDto> getBannerById(@PathVariable Long id) {
+        return ResponseEntity.ok(bannerService.getBannerById(id));
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerController.java
@@ -1,12 +1,15 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
 import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "banners", description = "홈화면 상단 배너 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/banners")
@@ -15,6 +18,7 @@ public class BannerController {
     private final BannerService bannerService;
 
     @GetMapping
+    @Operation(summary = "상단 배너 전체 불러오기", description = "배너id와 배너 이미지 url을 list로 불러옵니다.")
     public ResponseEntity<BannersResponse> getBanners() {
         return ResponseEntity.ok(bannerService.getAllBanners());
     }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerRepository.java
@@ -1,0 +1,6 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
@@ -1,8 +1,12 @@
 package com.swmarastro.mykkumiserver.domain.banner;
 
-import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannerDto;
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannerListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -10,10 +14,21 @@ public class BannerService {
 
     private final BannerRepository bannerRepository;
 
-    public BannersResponse getAllBanners() {
-        return BannersResponse.builder()
-                .banners(bannerRepository.findAll())
+    public BannerListResponse getAllBanners() {
+        List<BannerDto> bannerList = getSimpleBanners();
+        return BannerListResponse.builder()
+                .banners(bannerList)
                 .build();
+    }
+
+    private List<BannerDto> getSimpleBanners() {
+        List<Banner> bannerList = bannerRepository.findAll();
+        return bannerList.stream()
+                .map(banner -> BannerDto.builder()
+                        .id(banner.getId())
+                        .imageUrl(banner.getImageUrl())
+                        .build())
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
@@ -2,6 +2,8 @@ package com.swmarastro.mykkumiserver.domain.banner;
 
 import com.swmarastro.mykkumiserver.domain.banner.dto.BannerDto;
 import com.swmarastro.mykkumiserver.domain.banner.dto.BannerListResponse;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +20,15 @@ public class BannerService {
         List<BannerDto> bannerList = getSimpleBanners();
         return BannerListResponse.builder()
                 .banners(bannerList)
+                .build();
+    }
+
+    public BannerDto getBannerById(Long bannerId) {
+        Banner banner = bannerRepository.findById(bannerId)
+                .orElseThrow(() -> new CommonException(ErrorCode.BANNER_NOT_FOUND,"존재하지 않는 배너입니다.","해당 id의 배너를 찾을 수 없습니다."));
+        return BannerDto.builder()
+                .id(banner.getId())
+                .imageUrl(banner.getDetailImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
@@ -1,0 +1,19 @@
+package com.swmarastro.mykkumiserver.domain.banner;
+
+import com.swmarastro.mykkumiserver.domain.banner.dto.BannersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    public BannersResponse getAllBanners() {
+        return BannersResponse.builder()
+                .banners(bannerRepository.findAll())
+                .build();
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/BannerService.java
@@ -25,7 +25,7 @@ public class BannerService {
 
     public BannerDto getBannerById(Long bannerId) {
         Banner banner = bannerRepository.findById(bannerId)
-                .orElseThrow(() -> new CommonException(ErrorCode.BANNER_NOT_FOUND,"존재하지 않는 배너입니다.","해당 id의 배너를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND,"존재하지 않는 배너입니다.","해당 id의 배너를 찾을 수 없습니다."));
         return BannerDto.builder()
                 .id(banner.getId())
                 .imageUrl(banner.getDetailImageUrl())

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannerDto.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannerDto.java
@@ -1,0 +1,14 @@
+package com.swmarastro.mykkumiserver.domain.banner.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "배너 1개 DTO")
+@Getter
+@Builder
+public class BannerDto {
+
+    private Long id;
+    private String imageUrl;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannerListResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannerListResponse.java
@@ -1,6 +1,5 @@
 package com.swmarastro.mykkumiserver.domain.banner.dto;
 
-import com.swmarastro.mykkumiserver.domain.banner.Banner;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +9,7 @@ import java.util.List;
 @Schema(description = "홈화면 상단 배너 전체 List DTO")
 @Getter
 @Builder
-public class BannersResponse {
+public class BannerListResponse {
 
-    List<Banner> banners;
+    private List<BannerDto> banners;
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
@@ -1,11 +1,13 @@
 package com.swmarastro.mykkumiserver.domain.banner.dto;
 
 import com.swmarastro.mykkumiserver.domain.banner.Banner;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
+@Schema(description = "홈화면 상단 배너 전체 List DTO")
 @Getter
 @Builder
 public class BannersResponse {

--- a/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/domain/banner/dto/BannersResponse.java
@@ -1,0 +1,14 @@
+package com.swmarastro.mykkumiserver.domain.banner.dto;
+
+import com.swmarastro.mykkumiserver.domain.banner.Banner;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BannersResponse {
+
+    List<Banner> banners;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND),
+    // 404 NOT FOUND
+    NOT_FOUND(HttpStatus.NOT_FOUND),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,21 @@
 spring:
   application:
     name: mykkumi-server
+  config:
+    import: 'aws-secretsmanager:dev/mykkumi/mysql'
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${db_host}:${db_port}/dbMykkumiDev?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${db_username}
+    password: ${db_password}
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 server:
   port: 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,9 @@ spring:
   application:
     name: mykkumi-server
   config:
-    import: 'aws-secretsmanager:dev/mykkumi/mysql'
+    import:
+      - 'aws-secretsmanager:dev/mykkumi/mysql'
+      - 'aws-secretsmanager:dev/mykkumi/s3'
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${db_host}:${db_port}/dbMykkumiDev?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
@@ -11,13 +13,28 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
 server:
   port: 8080
+
+cloud:
+  aws:
+    s3:
+      bucket: ${s3_bucket_name}
+    credentials:
+      access-key: ${s3_access_key}
+      secret-key: ${s3_secret_key}
+    region:
+      auto: false
+      static: ${region}
+      use-default-aws-region-chain: true
+    stack:
+      auto: false
 
 springdoc:
   packages-to-scan: com.swmarastro.mykkumiserver


### PR DESCRIPTION
## 구현내용
### 1. 배너 하나 조회 api 구현
홈화면 상단에서 호출될 배너를 전체 조회하는 api를 구현했습니다.
#### 스프링 데이터 JPA 사용
>아래와 같이 스프링 데이터 JPA를 사용하였습니다.
>```java
>public interface BannerRepository extends JpaRepository<Banner, Long> {
>}
>.```
#### 엔티티에 detailImageUrl 추가
>처음에는 배너 엔티티에 아래 두개의 컬럼만 존재해서 간단히 만들었습니다. 
>```
>    private Long id;
>    private String imageUrl;
>```
>하지만 생각해보니 홈화면에서 보이는 배너는 요약된 대표화면이고, 클릭을 했을때 보이는 상세 이미지가 없다는 생각이 들었습니다. 그래>서 아래와 같이 detailImageUrl을 추가했습니다.
>```
>    private Long id;
>    private String imageUrl;
>    private String detailImageUrl;
>```
#### BannerService
>BannerService에서 리포지토리에 접근하여 banner_id로 디테일이미지를 찾아주는 부분을 구현했습니다. 
>```java
>    public BannerDto getBannerById(Long bannerId) {
>        Banner banner = bannerRepository.findById(bannerId)
>                .orElseThrow(() -> new CommonException(ErrorCode.BANNER_NOT_FOUND,"존재하지 않는 배너입니다.","해당 id의 배너를 찾을 수 없습니다."));
>        return BannerDto.builder()
>                .id(banner.getId())
>                .imageUrl(banner.getDetailImageUrl())
>                .build();
>    }
>```
>BannerDto를 만들어 사용했습니다.
>```java
>    public class BannerDto {
>        private Long id;
>        private String imageUrl;
>    }
>```
   
     
### 2. 배너 전체 조회 api 구현
홈화면 상단에서 보여줄 배너 전체를 조회하는 api를 구현했습니다.
하나 조회와 다르게, 상세이미지 대신 일반 이미지를 조회해주었습니다.
#### BannerService
>아래는 BannerService에서 구현한 부분인데, 코드가 길어지기에 getSimpleBanners() 메서드를 따로 분리했습니다.
>Banner엔티티에는 imageUrl과 detailImageUrl이 함께 있는데, 여기서 필요한 부분은 detailImageUrl이라 고민하다가 위에서 사용했던 `BannerDto를 다시 사용`해줬습니다.
>```java
>    public BannerListResponse getAllBanners() {
>        List<BannerDto> bannerList = getSimpleBanners();
>        return BannerListResponse.builder()
>                .banners(bannerList)
>                .build();
>    }
>
>     private List<BannerDto> getSimpleBanners() {
>        List<Banner> bannerList = bannerRepository.findAll();
>        return bannerList.stream()
>                .map(banner -> BannerDto.builder()
>                        .id(banner.getId())
>                        .imageUrl(banner.getImageUrl())
>                        .build())
>                .collect(Collectors.toList());
>    }
>```      
    
## 고민사항
### 1. 배너 전체 조회 api에서 메서드 두개로 분리해줬는데 하나에 해도 되는걸 괜히 쪼갰는지 고민중입니다.
하나에 다 넣어도 될 것 같은데 보통 어느정도 길이가 넘어가면 분리하는지 궁금합니다.
### 2. 예외의 크기가 적당한지 고민입니다.
```java
new CommonException(ErrorCode.BANNER_NOT_FOUND,"존재하지 않는 배너입니다.","해당 id의 배너를 찾을 수 없습니다.")
```
id로 배너 조회시 해당 id 배너가 존재하지 않는다면 위와 같이 예외처리를 했습니다. ErrorCode에 BANNER_NOT_FOUND라고 넣어놨는데, 크기를 너무 작게 잡아 재사용할 일이 없는 예외를 만든건지 고민입니다. 그냥 해당 자료가 없을 때, ErrorCode에는 NOT_FOUND 정도만 넣어놓고, 상세 설명에서 배너가 존재하지 않는다고 적어주는 것으로 바꿀지 고민입니다.
### 3. aws secrets 관리
aws secrets 관리를 위해 aws secrets manager를 사용했습니다.
예전에는 aws.yml과 같은 파일에 secrtes를 넣어두고 .gitignore에 해당 파일을 넣어 깃허브에 올라가지 않도록 했었습니다.
이번에는 시크릿 관리에 편리할 것 같아 secrets manager를 사용해봤습니다. 
**dev/mykkumi/s3**
![스크린샷 2024-06-26 오후 1 17 03](https://github.com/SW-Marastro/Mykkumi-BE/assets/59831262/bb350825-c029-431f-985f-a9427bd28f54)
위와 같이 aws에 올려준 결과 아래와 같이 secrets를 사용할 수 있었습니다.
**application.yml**
```
  config:
    import:
      - 'aws-secretsmanager:dev/mykkumi/s3'
    s3:
      bucket: ${s3_bucket_name}
    credentials:
      access-key: ${s3_access_key}
      secret-key: ${s3_secret_key}
```
### 4. aws secrets manager로 인한 ci에서의 에러
develop 브랜치에 다시 Merge해봐야겠지만 ci 과정 중 에러가 발생했습니다. 
아래와 같은 에러가 발생하는 것으로 확인됩니다. 
```
java.lang.IllegalStateException at DefaultCacheAwareContextLoaderDelegate.java:180
        Caused by: org.springframework.boot.context.config.ConfigDataResourceNotFoundException at ConfigDataResourceNotFoundException.java:97
            Caused by: io.awspring.cloud.secretsmanager.AwsSecretsManagerPropertySources$AwsSecretsManagerPropertySourceNotFoundException at AwsSecretsManagerPropertySources.java:93
                Caused by: com.amazonaws.SdkClientException at AWSCredentialsProviderChain.java:136
6 actionable tasks: 6 executed
FAILURE: Build failed with an exception.
```
코드 자체에 문제가 있나 싶어 파일을 scp로 직접 서버로 옮겨 실행시켜봤으나, 수동으로 옮겨 실행했을 때는 잘 실행되는 것을 확인했습니다. 원인을 잘 모르겠어서 일단 수동 배포해놓고 에러 원인을 찾아보며 고쳐보려고 합니다.