### PR TITLE
KKUMI-20 [FIX] #12 cursor값 아예 없으면 에러나는 부분 수정

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
     }
 
     private PostLatestCursor getCursorFromBase64String(String encodedCursor) {
-        if(encodedCursor.isEmpty())
+        if(encodedCursor==null || encodedCursor.isEmpty())
             return PostLatestCursor.of(LocalDateTime.now(), Long.MAX_VALUE);
         return Base64Utils.decode(encodedCursor, PostLatestCursor.class);
     }


### PR DESCRIPTION
/api/v1/posts?cursor=&limit= 는 동작되는데 
/api/v1/posts?limit= 는 500 에러나는 부분 수정
cursor와 limit는 필수값이 아니다.