### PR TITLE
KKUMI-39_jwt_util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ dependencies {
 
     //secrets manager
     implementation "io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4"
+
+    //jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProperties.java
@@ -1,9 +1,11 @@
 package com.swmarastro.mykkumiserver.auth.jwt;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+@Setter
 @Getter
 @Component
 @ConfigurationProperties("jwt")

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.swmarastro.mykkumiserver.auth.jwt;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+
+    private String issuer;
+    private String secretKey;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProvider.java
@@ -1,0 +1,76 @@
+package com.swmarastro.mykkumiserver.auth.jwt;
+
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
+import com.swmarastro.mykkumiserver.user.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Date;
+
+@Getter
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    /**
+     * 토큰 생성 메서드
+     */
+    public String generateToken(User user, Duration expireTime) {
+        final Date now = new Date();
+        final Date expiry = new Date(now.getTime() + expireTime.toMillis());
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject(String.valueOf(user.getId())) //토큰이름: userId
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getSigningKey(jwtProperties.getSecretKey()), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * 유효한 토큰인지 검사하는 메서드
+     */
+    public boolean validToken(String token) {
+        try {
+            Key key = getSigningKey(jwtProperties.getSecretKey());
+            getJwtParser()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new CommonException(ErrorCode.TOKEN_EXPIRED, "만료된 토큰입니다.", "토큰 유효기간이 지났습니다.");
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
+        }
+    }
+
+    /**
+     * 토큰 subject 가져오기(userId)
+     */
+    public Long getSubject(String token) {
+        return Long.valueOf(getJwtParser().parseClaimsJws(token)
+                .getBody()
+                .getSubject());
+    }
+
+    private JwtParser getJwtParser() {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey(jwtProperties.getSecretKey()))
+                .build();
+    }
+
+    private Key getSigningKey(String key) {
+        String encoded = Base64.getEncoder().encodeToString(key.getBytes());
+        return Keys.hmacShaKeyFor(encoded.getBytes());
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     // 404 NOT FOUND
     NOT_FOUND(HttpStatus.NOT_FOUND),
 
+    //500 INTERNAL_SERVER_ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
@@ -13,8 +13,13 @@ public enum ErrorCode {
     DECODING_ERROR(HttpStatus.BAD_REQUEST),
     INVALID_VALUE(HttpStatus.BAD_REQUEST),
 
+    //401 UNAUTHORIZED
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED),
+
     // 404 NOT FOUND
     NOT_FOUND(HttpStatus.NOT_FOUND),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorResponse.java
@@ -20,4 +20,12 @@ public class ErrorResponse {
                 .detail(e.getDetail())
                 .build();
     }
+
+    public static ErrorResponse from(Exception e) {
+        return ErrorResponse.builder()
+                .errorCode(ErrorCode.INTERNAL_SERVER_ERROR.getErrorCodeName())
+                .message("알 수 없는 에러입니다. 잠시 후 시도해주세요.")
+                .detail("서버 에러입니다.")
+                .build();
+    }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.global.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,6 +12,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = CommonException.class)
     public ResponseEntity<ErrorResponse> handle(CommonException e) {
         return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e));
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.from(e));
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
@@ -2,14 +2,9 @@ package com.swmarastro.mykkumiserver.post;
 
 import com.swmarastro.mykkumiserver.post.dto.PostListResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostRepository.java
@@ -11,4 +11,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     //TODO Querydsl로 추후 변경하기
     @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.id < :lastId AND p.isDeleted = false ORDER BY p.id DESC limit :limit")
     List<Post> findLatestOrderByIdDesc(Long lastId, Integer limit);
+
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.id < :lastId AND p.isDeleted = false ORDER BY p.id DESC")
+    Long countPostsByOrderByIdDesc(Long lastId);
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
@@ -30,6 +30,8 @@ public class PostService {
         List<PostDto> posts = getPostsByCursorAndLimit(cursor, limit);
 
         Long lastId = getLastIdFromPostList(posts);
+        if(postRepository.countPostsByOrderByIdDesc(lastId)==0L) //다음에 조회할 내용 없음
+            return PostListResponse.end(posts);
         PostLatestCursor nextCursor = PostLatestCursor.of(cursor.getStartedAt(), lastId);
         return PostListResponse.of(posts, Base64Utils.encode(nextCursor));
     }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
@@ -22,8 +22,8 @@ public class PostService {
     //TODO 이름에 최신순이라고 알려줘야할것 같다. 고민해보고 이름 고치기
     public PostListResponse getInfiniteScrollPosts(String encodedCursor, Integer limit) {
 
-        if (limit <= 0)
-            throw new CommonException(ErrorCode.INVALID_VALUE, "limit 값이 올바르지 않습니다.", "limit 값은 limit>0 이어야 합니다.");
+        if (limit <= 0 || limit > 10)
+            throw new CommonException(ErrorCode.INVALID_VALUE, "limit 값이 올바르지 않습니다.", "limit 값은 1<=limit<=10 이어야 합니다.");
 
         //TODO Cursor 인터페이스 하나 놓고 상속해서 커스텀하여 사용할 수도 있을 것 같다. 추후 구조 수정
         PostLatestCursor cursor = getCursorFromBase64String(encodedCursor);

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostListResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostListResponse.java
@@ -21,4 +21,12 @@ public class PostListResponse {
                 .cursor(cursor)
                 .build();
     }
+
+    //포스트 끝
+    public static PostListResponse end(List<PostDto> posts) {
+        return PostListResponse.builder()
+                .posts(posts)
+                .cursor("")
+                .build();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
     import:
       - 'aws-secretsmanager:dev/mykkumi/mysql'
       - 'aws-secretsmanager:dev/mykkumi/s3'
+      - 'aws-secretsmanager:dev/mykkumi/jwt'
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${db_host}:${db_port}/dbMykkumiDev?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
@@ -45,3 +46,7 @@ springdoc:
     disable-swagger-default-url: true
     display-request-duration: true
     operations-sorter: alpha
+
+jwt:
+  issuer: ${jwt_issuer}
+  secret_key: ${jwt_secret_key}


### PR DESCRIPTION
## 구현내용
### 1. JwtProvider 구현
Jwt 관련 util 클래스를 생성했습니다.
**기능**
- jwt 생성
- jwt 유효성 검증
- jwt 에서 subject 추출

### 2. ErrorCode 500 추가
Internal Server Error를 처리하기 위한 코드를 추가했습니다.
기존: CommonException으로 던진 예외만 ErrorResponse 형식으로 처리
변경후: CommonException 제외한 모든 예외 500에러로 ErrorResponse 형식으로 처리

### 3. 포스트 무한스크롤 요청 최대 10개 제한 추가
최대 10개 요청할 수 있다는 로직이 없었어서 추가했습니다.

### 4. 무한스크롤 포스트 더 이상 조회할 포스트가 없다면 cursor값 ""
기존: 한번 더 api를 호출해서 빈 posts가 와야 끝났음을 알 수 있었습니다.
변경후: 마지막 posts면 cursor값에 ""를 보내줘서 한번 더 api를 호출하지 않아도 끝임을 알 수있도록 했습니다.