### PR TITLE
KKUMI-52_token_service

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProvider.java
@@ -21,15 +21,19 @@ public class JwtProvider {
 
     private final JwtProperties jwtProperties;
 
+    public String generateToken(User user, Duration duration) {
+        Date now = new Date();
+        return makeToken(user, new Date(now.getTime() + duration.toMillis()));
+    }
+
     /**
      * 토큰 생성 메서드
      */
-    public String generateToken(User user, Duration expireTime) {
-        final Date now = new Date();
-        final Date expiry = new Date(now.getTime() + expireTime.toMillis());
+    private String makeToken(User user, Date expiry) {
+        Date now = new Date();
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setSubject(String.valueOf(user.getId())) //토큰이름: userId
+                .setSubject(String.valueOf(user.getUuid())) //토큰이름: user uuid
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .signWith(getSigningKey(jwtProperties.getSecretKey()), SignatureAlgorithm.HS256)
@@ -54,12 +58,21 @@ public class JwtProvider {
     }
 
     /**
-     * 토큰 subject 가져오기(userId)
+     * 토큰 subject 가져오기(user uuid)
      */
-    public Long getSubject(String token) {
-        return Long.valueOf(getJwtParser().parseClaimsJws(token)
+    public String getSubject(String token) {
+        return getJwtParser().parseClaimsJws(token)
                 .getBody()
-                .getSubject());
+                .getSubject();
+    }
+
+    /**
+     * 토큰 만료시각 가져오기
+     */
+    public Date getExpiry(String token) {
+        return getJwtParser().parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
     }
 
     private JwtParser getJwtParser() {

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/AuthTokensDTO.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/AuthTokensDTO.java
@@ -1,0 +1,19 @@
+package com.swmarastro.mykkumiserver.auth.token;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AuthTokensDTO {
+
+    private String refreshToken;
+    private String accessToken;
+
+    public static AuthTokensDTO of(String refreshToken, String accessToken) {
+        return AuthTokensDTO.builder()
+                .refreshToken(refreshToken)
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
@@ -22,7 +22,7 @@ public class RefreshToken {
     public Long id;
 
     @Column(updatable = false, nullable = false, unique = true, insertable = false)
-    private UUID uuid;
+    private String uuid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -38,7 +38,7 @@ public class RefreshToken {
         return RefreshToken.builder()
                 .user(user)
                 .refreshToken(token)
-                .uuid(UUID.randomUUID())
+                .uuid(UUID.randomUUID().toString())
                 .tokenExpiry(expiry)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
@@ -22,7 +22,7 @@ public class RefreshToken {
     public Long id;
 
     @Column(updatable = false, nullable = false, unique = true, insertable = false)
-    private String uuid;
+    private UUID uuid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -38,7 +38,7 @@ public class RefreshToken {
         return RefreshToken.builder()
                 .user(user)
                 .refreshToken(token)
-                .uuid(UUID.randomUUID().toString())
+                .uuid(UUID.randomUUID())
                 .tokenExpiry(expiry)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
@@ -1,0 +1,46 @@
+package com.swmarastro.mykkumiserver.auth.token;
+
+import com.swmarastro.mykkumiserver.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id", updatable = false, nullable = false)
+    public Long id;
+
+    @Column(updatable = false, nullable = false, unique = true, insertable = false)
+    private UUID uuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String refreshToken;
+    private Date tokenExpiry;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public static RefreshToken of(User user, String token, Date expiry) {
+        return RefreshToken.builder()
+                .user(user)
+                .refreshToken(token)
+                .uuid(UUID.randomUUID())
+                .tokenExpiry(expiry)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
@@ -34,11 +34,11 @@ public class RefreshToken {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public static RefreshToken of(User user, String token, Date expiry) {
+    public static RefreshToken of(User user, String token, Date expiry, UUID uuid) {
         return RefreshToken.builder()
                 .user(user)
                 .refreshToken(token)
-                .uuid(UUID.randomUUID())
+                .uuid(uuid)
                 .tokenExpiry(expiry)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshTokenRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.swmarastro.mykkumiserver.auth.token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshTokenRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshTokenRepository.java
@@ -3,9 +3,10 @@ package com.swmarastro.mykkumiserver.auth.token;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+    Optional<RefreshToken> findByUuid(UUID uuid);
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.Date;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -23,35 +24,61 @@ public class TokenService {
     private final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(90);
 
     /**
-     * refresh token으로 access token 생성
+     * refresh token으로 refresh token, access token 재발급
      */
-    public String createNewAccessToken(String refreshToken) {
-
-        //유효한 토큰인지 확인
-        if(!jwtProvider.validToken(refreshToken)) {
+    public AuthTokensDTO createNewTokens(String refreshToken) {
+        if (!isValidToken(refreshToken)) {
             throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
         }
-        //DB에 존재하는지 확인
-        refreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다."));
-        //토큰에서 유저 uuid 추출
-        String Uuid = jwtProvider.getSubject(refreshToken);
-        //해당 유저 존재하는지 확인
-        User user = userService.getUserByUuid(Uuid);
+        //refresh token 발급
+        User user = userService.getUserByUuid(jwtProvider.getSubject(refreshToken));
+        String newRefreshToken = createRefreshToken(user);
+
+        //access token 발급
+        String newAccessToken = createNewAccessToken(user, newRefreshToken);
+        return AuthTokensDTO.of(newRefreshToken, newAccessToken);
+    }
+
+    /**
+     * refresh token으로 access token 생성
+     */
+    private String createNewAccessToken(User user, String refreshToken) {
         return jwtProvider.generateToken(user, ACCESS_TOKEN_DURATION);
     }
 
     /**
      * refresh token 생성
      */
-    public String createRefreshToken(User user) {
+    private String createRefreshToken(User user) {
+        UUID tokenUuid = UUID.randomUUID();
         //user의 refresh token 생성
-        String token = jwtProvider.generateToken(user, REFRESH_TOKEN_DURATION);
+        String token = jwtProvider.generateToken(user, REFRESH_TOKEN_DURATION, tokenUuid);
         //DB에 저장 - TODO 업데이트 칠건지? 새로 만들건지? -> 일단 새로 만드는 것으로 구현
         Date expiry = jwtProvider.getExpiry(token);
-        refreshTokenRepository.save(RefreshToken.of(user, token, expiry));
+        refreshTokenRepository.save(RefreshToken.of(user, token, expiry, tokenUuid));
         return token;
     }
 
+    /**
+     * 유효한 refresh token인지, 사용자는 실제로 존재하는지 검증
+     */
+    public boolean isValidToken(String refreshToken) {
+        //유효한 토큰인지 확인
+        if(!jwtProvider.validToken(refreshToken)) {
+            throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
+        }
+
+        //claim에서 refresh token의 uuid 가져오기
+        UUID uuid = jwtProvider.getUuidFromClaim(refreshToken);
+
+        //DB에 존재하는지 확인
+        refreshTokenRepository.findByUuid(uuid)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다."));
+        //토큰에서 유저 uuid 추출
+        String Uuid = jwtProvider.getSubject(refreshToken);
+        //해당 유저 존재하는지 확인
+        User user = userService.getUserByUuid(Uuid);
+        return true;
+    }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
@@ -1,0 +1,57 @@
+package com.swmarastro.mykkumiserver.auth.token;
+
+import com.swmarastro.mykkumiserver.auth.jwt.JwtProvider;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
+import com.swmarastro.mykkumiserver.user.User;
+import com.swmarastro.mykkumiserver.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserService userService;
+
+    private final Duration ACCESS_TOKEN_DURATION = Duration.ofMinutes(15);
+    private final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(90);
+
+    /**
+     * refresh token으로 access token 생성
+     */
+    public String createNewAccessToken(String refreshToken) {
+
+        //유효한 토큰인지 확인
+        if(!jwtProvider.validToken(refreshToken)) {
+            throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
+        }
+        //DB에 존재하는지 확인
+        refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다."));
+        //토큰에서 유저 uuid 추출
+        String Uuid = jwtProvider.getSubject(refreshToken);
+        //해당 유저 존재하는지 확인
+        User user = userService.getUserByUuid(Uuid);
+        return jwtProvider.generateToken(user, ACCESS_TOKEN_DURATION);
+    }
+
+    /**
+     * refresh token 생성
+     */
+    public String createRefreshToken(User user) {
+        //user의 refresh token 생성
+        String token = jwtProvider.generateToken(user, REFRESH_TOKEN_DURATION);
+        //DB에 저장 - TODO 업데이트 칠건지? 새로 만들건지? -> 일단 새로 만드는 것으로 구현
+        Date expiry = jwtProvider.getExpiry(token);
+        refreshTokenRepository.save(RefreshToken.of(user, token, expiry));
+        return token;
+    }
+
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
@@ -31,7 +31,7 @@ public class TokenService {
             throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
         }
         //refresh token 발급
-        User user = userService.getUserByUuid(jwtProvider.getSubject(refreshToken));
+        User user = userService.getUserByUuid(UUID.fromString(jwtProvider.getSubject(refreshToken)));
         String newRefreshToken = createRefreshToken(user);
 
         //access token 발급
@@ -75,7 +75,7 @@ public class TokenService {
         refreshTokenRepository.findByUuid(uuid)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다."));
         //토큰에서 유저 uuid 추출
-        String Uuid = jwtProvider.getSubject(refreshToken);
+        UUID Uuid = UUID.fromString(jwtProvider.getSubject(refreshToken));
         //해당 유저 존재하는지 확인
         User user = userService.getUserByUuid(Uuid);
         return true;

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostRepository.java
@@ -11,7 +11,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     //TODO Querydsl로 추후 변경하기
     @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.id < :lastId AND p.isDeleted = false ORDER BY p.id DESC limit :limit")
     List<Post> findLatestOrderByIdDesc(Long lastId, Integer limit);
-
-    @Query("SELECT COUNT(p) FROM Post p WHERE p.id < :lastId AND p.isDeleted = false ORDER BY p.id DESC")
-    Long countPostsByOrderByIdDesc(Long lastId);
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostService.java
@@ -27,11 +27,13 @@ public class PostService {
 
         //TODO Cursor 인터페이스 하나 놓고 상속해서 커스텀하여 사용할 수도 있을 것 같다. 추후 구조 수정
         PostLatestCursor cursor = getCursorFromBase64String(encodedCursor);
-        List<PostDto> posts = getPostsByCursorAndLimit(cursor, limit);
+        List<PostDto> posts = getPostsByCursorAndLimit(cursor, limit + 1);
 
-        Long lastId = getLastIdFromPostList(posts);
-        if(postRepository.countPostsByOrderByIdDesc(lastId)==0L) //다음에 조회할 내용 없음
+        if (posts.size() < limit + 1) { //다음에 조회할 내용 없음
             return PostListResponse.end(posts);
+        }
+        posts.removeLast();
+        Long lastId = getLastIdFromPostList(posts);
         PostLatestCursor nextCursor = PostLatestCursor.of(cursor.getStartedAt(), lastId);
         return PostListResponse.of(posts, Base64Utils.encode(nextCursor));
     }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -14,7 +14,7 @@ public class User {
     @Column(name = "user_id")
     private Long id;
     @Column(updatable = false, nullable = false, unique = true, insertable = false)
-    private String uuid;
+    private UUID uuid;
     @Column(nullable = false)
     private String nickname;
     @Column(nullable = false)

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -13,7 +13,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
-    @Column(updatable = false, nullable = false, unique = true, insertable = false)
+    @Column(updatable = false, nullable = false, unique = true, columnDefinition = "CHAR(36)")
     private UUID uuid;
     @Column(nullable = false)
     private String nickname;
@@ -21,4 +21,11 @@ public class User {
     private String email;
     private String introduction;
     private String profileImage;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.uuid == null) {
+            this.uuid = UUID.randomUUID();
+        }
+    }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -3,6 +3,8 @@ package com.swmarastro.mykkumiserver.user;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.util.UUID;
+
 @Getter
 @Entity
 public class User {
@@ -11,6 +13,8 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
+    @Column(updatable = false, nullable = false, unique = true, insertable = false)
+    private UUID uuid;
     @Column(nullable = false)
     private String nickname;
     @Column(nullable = false)

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -14,7 +14,7 @@ public class User {
     @Column(name = "user_id")
     private Long id;
     @Column(updatable = false, nullable = false, unique = true, insertable = false)
-    private UUID uuid;
+    private String uuid;
     @Column(nullable = false)
     private String nickname;
     @Column(nullable = false)

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserRepository.java
@@ -2,5 +2,9 @@ package com.swmarastro.mykkumiserver.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUuid(String uuid);
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserRepository.java
@@ -3,8 +3,9 @@ package com.swmarastro.mykkumiserver.user;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUuid(String uuid);
+    Optional<User> findByUuid(UUID uuid);
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
@@ -5,13 +5,15 @@ import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
 
-    public User getUserByUuid(String uuid) {
+    public User getUserByUuid(UUID uuid) {
         return userRepository.findByUuid(uuid)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND, "유저가 존재하지 않습니다.", "해당 uuid의 유저가 존재하지 않습니다."));
 

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
@@ -1,0 +1,19 @@
+package com.swmarastro.mykkumiserver.user;
+
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User getUserByUuid(String uuid) {
+        return userRepository.findByUuid(uuid)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND, "유저가 존재하지 않습니다.", "해당 uuid의 유저가 존재하지 않습니다."));
+
+    }
+}


### PR DESCRIPTION
## 구현내용
### 1. Refresh, Access token 생성 기능
#### * 유효기간
Refresh token은 애플리케이션 서비스인 것을 고려해서 90일로, Access token은 15분으로 설정했습니다.
```java
private final Duration ACCESS_TOKEN_DURATION = Duration.ofMinutes(15);
private final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(90);
```

#### * JWT의 subject는 user의 UUID
토큰의 subject에는 user의 UUID를 넣어주었습니다. 
기존에는 user의 id를 그대로 넣었지만, 아래와 같은 이유로 변경했습니다.

1. 보안성
auto increment되는 Id를 그대로 사용하게 되면 DB에 row가 몇개 있는지 등 유추가 가능해집니다.
보안성을 높이기 위해 UUID를 생성하여 넣어주었습니다.
2. DB 이전 가능성
올해 말쯤 aws 계정을 다른 계정으로 옮겨야 합니다. 옮길 때 auto increment 되는 값은 그대로 유지될지  확언할 수 없다는 조언을 듣고 UUID를 사용하기로 했습니다.

### 2. 포스트 무한스크롤 마지막인지 확인하는 로직 변경
무한스크롤이 끝났는지 확인하기 위해, limit+1 값을 조회하여 limit+1보다 작은 값이 조회되면 끝난 것으로 판단하기로 했습니다.
기존에는 남은 포스트의 개수를 세는 쿼리가 한번 더 나가게 되었는데, 현재 방식으로 변경하면서 쿼리가 한번만 나가게 되었습니다.