### PR TITLE
KKUMI-41_kakao_login

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
@@ -1,0 +1,26 @@
+package com.swmarastro.mykkumiserver.auth;
+
+import com.swmarastro.mykkumiserver.auth.dto.SigninRequest;
+import com.swmarastro.mykkumiserver.auth.dto.SigninResponse;
+import com.swmarastro.mykkumiserver.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signin/kakao")
+    public ResponseEntity<SigninResponse> signinKakao(@RequestBody SigninRequest request) {
+        SigninResponse signinResponse = authService.signin(request, OAuthProvider.KAKAO);
+        return ResponseEntity.ok()
+                .body(signinResponse);
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
@@ -1,8 +1,11 @@
 package com.swmarastro.mykkumiserver.auth;
 
+import com.swmarastro.mykkumiserver.auth.dto.NewAccessTokenRequest;
+import com.swmarastro.mykkumiserver.auth.dto.NewAccessTokenResponse;
 import com.swmarastro.mykkumiserver.auth.dto.SigninRequest;
 import com.swmarastro.mykkumiserver.auth.dto.SigninResponse;
 import com.swmarastro.mykkumiserver.auth.service.AuthService;
+import com.swmarastro.mykkumiserver.auth.token.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,11 +19,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final TokenService tokenService;
 
     @PostMapping("/signin/kakao")
     public ResponseEntity<SigninResponse> signinKakao(@RequestBody SigninRequest request) {
         SigninResponse signinResponse = authService.signin(request, OAuthProvider.KAKAO);
         return ResponseEntity.ok()
                 .body(signinResponse);
+    }
+
+    @PostMapping("/token")
+    public ResponseEntity<NewAccessTokenResponse> getNewAccessToken(@RequestBody NewAccessTokenRequest request) {
+        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+        NewAccessTokenResponse newAccessTokenResponse = NewAccessTokenResponse.of(newAccessToken);
+        return ResponseEntity.ok()
+                .body(newAccessTokenResponse);
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/KakaoProperties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/KakaoProperties.java
@@ -1,0 +1,19 @@
+package com.swmarastro.mykkumiserver.auth;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class KakaoProperties {
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Value(("${spring.security.oauth2.client.provider.kakao.user-info-uri}"))
+    private String userInfoUri;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/OAuthProvider.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/OAuthProvider.java
@@ -1,0 +1,6 @@
+package com.swmarastro.mykkumiserver.auth;
+
+public enum OAuthProvider {
+
+    KAKAO, APPLE;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/NewAccessTokenRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/NewAccessTokenRequest.java
@@ -1,0 +1,9 @@
+package com.swmarastro.mykkumiserver.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NewAccessTokenRequest {
+
+    private String refreshToken;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/NewAccessTokenResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/NewAccessTokenResponse.java
@@ -1,0 +1,17 @@
+package com.swmarastro.mykkumiserver.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class NewAccessTokenResponse {
+
+    private String accessToken;
+
+    public static NewAccessTokenResponse of(String accessToken) {
+        return NewAccessTokenResponse.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninRequest.java
@@ -1,0 +1,14 @@
+package com.swmarastro.mykkumiserver.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SigninRequest {
+
+    private String refreshToken;
+    private String accessToken;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninResponse.java
@@ -1,0 +1,23 @@
+package com.swmarastro.mykkumiserver.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class SigninResponse {
+
+    private String refreshToken;
+    private String accessToken;
+
+    public static SigninResponse of(String refreshToken, String accessToken) {
+        return SigninResponse.builder()
+                .refreshToken(refreshToken)
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/jwt/JwtProvider.java
@@ -42,7 +42,7 @@ public class JwtProvider {
                 .setSubject(String.valueOf(user.getUuid())) //토큰이름: user uuid
                 .setIssuedAt(now)
                 .setExpiration(expiry)
-                .claim("uuid", uuid)
+                .claim("uuid", uuid.toString())
                 .signWith(getSigningKey(jwtProperties.getSecretKey()), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -96,9 +96,9 @@ public class JwtProvider {
                 .getExpiration();
     }
 
-    public UUID getUuidFromClaim(String token) {
+    public String getUuidFromClaim(String token) {
         return getJwtParser().parseClaimsJws(token)
-                .getBody().get("uuid", UUID.class);
+                .getBody().get("uuid").toString();
     }
 
     private JwtParser getJwtParser() {

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/service/AuthService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/service/AuthService.java
@@ -1,0 +1,59 @@
+package com.swmarastro.mykkumiserver.auth.service;
+
+import com.swmarastro.mykkumiserver.auth.OAuthProvider;
+import com.swmarastro.mykkumiserver.auth.dto.SigninRequest;
+import com.swmarastro.mykkumiserver.auth.dto.SigninResponse;
+import com.swmarastro.mykkumiserver.auth.token.TokenService;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
+import com.swmarastro.mykkumiserver.user.User;
+import com.swmarastro.mykkumiserver.user.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoService kakaoService;
+    private final UserService userService;
+    private final TokenService tokenService;
+
+    public SigninResponse signin(SigninRequest request, OAuthProvider oAuthProvider) {
+        //사용자 이메일 받아오기
+        String email = getEmail(request.getAccessToken(), oAuthProvider);
+        //유저 찾기
+        User user = getUserByEmailAndProvider(email, oAuthProvider);
+        //우리 서비스 토큰 발급
+        String refreshToken = tokenService.createRefreshToken(user);
+        String accessToken = null;
+        try {
+            accessToken = tokenService.createNewAccessToken(refreshToken);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "알 수 없는 에러가 발생했습니다. 잠시 후 다시 시도해주세요", "access token 생성에 실패했습니다.");
+        }
+        return SigninResponse.of(refreshToken, accessToken);
+    }
+
+    User getUserByEmailAndProvider(String email, OAuthProvider oAuthProvider) {
+        //사용자 이미 가입된 사용자인지 구분하기
+        Optional<User> userOptional = userService.getUserByEmailAndProvider(email, oAuthProvider);
+        if (userOptional.isPresent()) { //가입된 사용자
+            return userOptional.get();
+        } else { //신규가입, 사용자 회원가입 시키기
+            return userService.saveUser(OAuthProvider.KAKAO, email);
+        }
+    }
+
+    String getEmail(String accessToken, OAuthProvider oAuthProvider) {
+        if (oAuthProvider == OAuthProvider.KAKAO) {
+            return kakaoService.getKakaoInfo(accessToken);
+        }
+        throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다. 다시 시도해주세요.", "OAuth2 사용자 정보를 가져오는데 실패했습니다.");
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/service/KakaoService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/service/KakaoService.java
@@ -1,0 +1,57 @@
+package com.swmarastro.mykkumiserver.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swmarastro.mykkumiserver.auth.KakaoProperties;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final String BEARER = "Bearer ";
+    private final KakaoProperties kakaoProperties;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 카카오 엑세스 토큰으로 사용자 정보 받아오기
+     */
+    public String getKakaoInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", BEARER + accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(kakaoProperties.getUserInfoUri(), HttpMethod.GET, entity, String.class);
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return parseUserInfo(response.getBody());
+            }
+            throw new CommonException(ErrorCode.INVALID_TOKEN, "토큰이 유효하지 않습니다.", "해당 카카오 토큰으로 유저 정보를 가져올 수 없습니다.");
+        } catch (Exception e) {
+            log.error("Failed to get Kakao user info: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INVALID_TOKEN, "토큰이 유효하지 않습니다.", "해당 카카오 토큰으로 유저 정보를 가져올 수 없습니다.");
+        }
+    }
+
+    private String parseUserInfo(String responseBody) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(responseBody);
+            return jsonNode.path("kakao_account").path("email").asText("");
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Kakao user info: {}", e.getMessage(), e);
+            throw new RuntimeException("Kakao API error: Invalid JSON format", e);
+        }
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
@@ -21,7 +21,7 @@ public class RefreshToken {
     @Column(name = "refresh_token_id", updatable = false, nullable = false)
     public Long id;
 
-    @Column(updatable = false, nullable = false, unique = true, insertable = false)
+    @Column(updatable = false, unique = true)
     private UUID uuid;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
@@ -24,32 +24,23 @@ public class TokenService {
     private final Duration REFRESH_TOKEN_DURATION = Duration.ofDays(90);
 
     /**
-     * refresh token으로 refresh token, access token 재발급
+     * refresh token으로 user의 access token 재발급
      */
-    public AuthTokensDTO createNewTokens(String refreshToken) {
+    public String createNewAccessTokens(String refreshToken) {
         if (!isValidToken(refreshToken)) {
             throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
         }
-        //refresh token 발급
-        User user = userService.getUserByUuid(UUID.fromString(jwtProvider.getSubject(refreshToken)));
-        String newRefreshToken = createRefreshToken(user);
-
-        //access token 발급
-        String newAccessToken = createNewAccessToken(user, newRefreshToken);
-        return AuthTokensDTO.of(newRefreshToken, newAccessToken);
-    }
-
-    /**
-     * refresh token으로 access token 생성
-     */
-    private String createNewAccessToken(User user, String refreshToken) {
+        //토큰에서 유저 uuid 추출
+        UUID Uuid = UUID.fromString(jwtProvider.getSubject(refreshToken));
+        //유저 가져오기
+        User user = userService.getUserByUuid(Uuid);
         return jwtProvider.generateToken(user, ACCESS_TOKEN_DURATION);
     }
 
     /**
      * refresh token 생성
      */
-    private String createRefreshToken(User user) {
+    public String createRefreshToken(User user) {
         UUID tokenUuid = UUID.randomUUID();
         //user의 refresh token 생성
         String token = jwtProvider.generateToken(user, REFRESH_TOKEN_DURATION, tokenUuid);

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
@@ -6,6 +6,8 @@ import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import com.swmarastro.mykkumiserver.user.User;
 import com.swmarastro.mykkumiserver.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -16,6 +18,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class TokenService {
 
+    private static final Logger log = LoggerFactory.getLogger(TokenService.class);
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserService userService;
@@ -26,14 +29,14 @@ public class TokenService {
     /**
      * refresh token으로 user의 access token 재발급
      */
-    public String createNewAccessTokens(String refreshToken) {
+    public String createNewAccessToken(String refreshToken) {
         if (!isValidToken(refreshToken)) {
             throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
         }
         //토큰에서 유저 uuid 추출
-        UUID Uuid = UUID.fromString(jwtProvider.getSubject(refreshToken));
+        UUID uuid = UUID.fromString(jwtProvider.getSubject(refreshToken));
         //유저 가져오기
-        User user = userService.getUserByUuid(Uuid);
+        User user = userService.getUserByUuid(uuid);
         return jwtProvider.generateToken(user, ACCESS_TOKEN_DURATION);
     }
 
@@ -60,7 +63,7 @@ public class TokenService {
         }
 
         //claim에서 refresh token의 uuid 가져오기
-        UUID uuid = jwtProvider.getUuidFromClaim(refreshToken);
+        UUID uuid = UUID.fromString(jwtProvider.getUuidFromClaim(refreshToken));
 
         //DB에 존재하는지 확인
         refreshTokenRepository.findByUuid(uuid)

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -6,9 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
 
+@Slf4j
 @Getter
 @Entity
 @Builder
@@ -20,9 +22,8 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
-    @Column(updatable = false, nullable = false, unique = true, columnDefinition = "CHAR(36)")
+    @Column(updatable = false, nullable = false, unique = true, columnDefinition = "BINARY(16)")
     private UUID uuid;
-    @Column(nullable = false)
     private String nickname;
     @Column(nullable = false)
     private String email;
@@ -32,17 +33,11 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private OAuthProvider provider;
 
-    @PrePersist
-    public void prePersist() {
-        if (this.uuid == null) {
-            this.uuid = UUID.randomUUID();
-        }
-    }
-
     public static User of(OAuthProvider provider, String email) {
         return User.builder()
                 .provider(provider)
                 .email(email)
+                .uuid(UUID.randomUUID())
                 .build();
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -1,12 +1,19 @@
 package com.swmarastro.mykkumiserver.user;
 
+import com.swmarastro.mykkumiserver.auth.OAuthProvider;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
 @Getter
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class User {
 
     @Id
@@ -22,10 +29,20 @@ public class User {
     private String introduction;
     private String profileImage;
 
+    @Enumerated(value = EnumType.STRING)
+    private OAuthProvider provider;
+
     @PrePersist
     public void prePersist() {
         if (this.uuid == null) {
             this.uuid = UUID.randomUUID();
         }
+    }
+
+    public static User of(OAuthProvider provider, String email) {
+        return User.builder()
+                .provider(provider)
+                .email(email)
+                .build();
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserRepository.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.user;
 
+import com.swmarastro.mykkumiserver.auth.OAuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,5 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUuid(UUID uuid);
+    Optional<User> findByEmailAndProvider(String email, OAuthProvider provider);
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
@@ -1,10 +1,12 @@
 package com.swmarastro.mykkumiserver.user;
 
+import com.swmarastro.mykkumiserver.auth.OAuthProvider;
 import com.swmarastro.mykkumiserver.global.exception.CommonException;
 import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -17,5 +19,13 @@ public class UserService {
         return userRepository.findByUuid(uuid)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND, "유저가 존재하지 않습니다.", "해당 uuid의 유저가 존재하지 않습니다."));
 
+    }
+
+    public User saveUser(OAuthProvider provider, String email) {
+        return userRepository.save(User.of(provider, email));
+    }
+
+    public Optional<User> getUserByEmailAndProvider(String email, OAuthProvider provider) {
+        return userRepository.findByEmailAndProvider(email, provider);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
       - 'aws-secretsmanager:dev/mykkumi/mysql'
       - 'aws-secretsmanager:dev/mykkumi/s3'
       - 'aws-secretsmanager:dev/mykkumi/jwt'
+      - 'aws-secretsmanager:dev/mykkumi/oauth'
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${db_host}:${db_port}/dbMykkumiDev?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
@@ -19,6 +20,26 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+        registration:
+          kakao:
+            client-id: ${kakao_client_id}
+            client-secret: ${kakao_client_secret}
+            client-authentication-method: client_secret_post
+            scope:
+              - account_email
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
 
 server:
   port: 8080


### PR DESCRIPTION
## 구현내용
### 1. 카카오 로그인
클라이언트에서 카카오의 리프레시, 엑세스 토큰을 받아왔습니다. 서비스의 클라이언트가 안드로이드, iOS 앱이기에 가능하다고 합니다. 받아온 카카오의 엑세스 토큰으로 카카오에서 유저의 이메일을 받아왔습니다. 이 이메일로 이미 가입된 사용자인지 체크를 했습니다.
- 이미 가입된 사용자이면 그대로 마이꾸미 서비스의 자체 토큰들을 응답해줬습니다.
- 신규 사용자면 서비스에 임시 가입시키고 마찬가지로 마이꾸미 서비스의 자체 토큰들을 응답해줬습니다.   

### 2. User, RefreshToken entity에 UUID 추가
#### - User에 UUID 추가
User에 UUID를 추가해줬습니다.
```java
public class RefreshToken {
    @Column(updatable = false, unique = true)
    private UUID uuid;
}
```
jwt의 subject에 기존에는 auto increment되는 userId를 그대로 넣어줬습니다. 하지만 다음 두 가지 이유로 UUID를 추가하게되었습니다.
1. userId가 유출되면 user 테이블에 row의 개수를 유추할 수 있어 보안적으로 좋지 않다.
2. 이번년도 말쯤 DB를 이전해야 하는데, auto increment되는 userId는 그대로 유지될 것이라고 확신할 수 없다.

#### - RefreshToken에 UUID 추가
마찬가지로 RefreshToken에도 UUID를 추가해줬습니다.
```java
public class User {
    @Column(updatable = false, nullable = false, unique = true, columnDefinition = "BINARY(16)")
    private UUID uuid;
}
```
이유는 아래 두 가지입니다.
1. refreshToken으로 DB에서 검색하면 너무 길어서 검색 성능이 좋지않아, uuid로 인덱스를 걸어주고 uuid로 검색하는 것이 유리하다.
2. 마찬가지로 이번년도 말쯤 DB를 이전해야 하는데, auto increment되는 userId는 그대로 유지될 것이라고 확신할 수 없다.

### 3. 마이꾸미 refreshToken으로 accessToken 재발급 api
해당 api도 구현했습니다.

## 고민사항
### 1. 예외 처리
정확히 어떤 상황에서 누구의 잘못으로 예외가 발생한 것인지 판단하기가 쉽지 않았습니다. 고민하다가 넣어보긴 했는데 이게 서버측 에러가 정확한지, 클라이언트 쪽 에러인지 아직도 애매한 부분이 있습니다.

### 2. 엑세스 토큰을 클라이언트에서 받아오다니!
전에 카카오 로그인을 구현할 때에는 rest api로만 구현했기에, 클라이언트는 1회용은 인가코드만을 받아서 서버에 넘겨줬습니다. 그러면 서버에서 그 인가코드를 가지고 리프레시, 엑세스 토큰을 가져왔었습니다. 당시 보안적으로 이렇게 하는 것이 맞다고 하여 그런줄만 알고있었습니다. 그래서 이대로 구현했었으나, 안드로이드 카카오 로그인 api 공식문서를 보다보니 이상한 점을 발견했습니다. 안드로이드 SDK를 사용하여 카카오 로그인 구현시, 앱에서 엑세스 토큰까지 다 가져오는 방법이 적혀있었습니다. 그래서 주변에 물어보고 구글링한 결과, 앱에서는 SDK에서 보안처리를 해주기 때문에 맞는 방법이라는 결론을 얻어, 구현했던 부분을 수정했습니다.

### 3. 토큰은 발급했으나 접근 제한이 걸려있지 않습니다.
토큰은 발급한 상태지만, 아직 접근이 제한되어야 하는 기능이 없어 접근 제한은 걸지 않은 상태입니다. 로그인쪽 기능 이후 포스트 작성과 같이 로그인이 꼭 필요한 기능을 개발할 예정이라, 그때 함께 붙여보겠습니다.
