### PR TITLE
KKUMI-38 user info _ 로그인된 유저 정보 조회

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/auth/Login.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/Login.java
@@ -1,0 +1,11 @@
+package com.swmarastro.mykkumiserver.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.swmarastro.mykkumiserver.auth;
+
+import com.swmarastro.mykkumiserver.auth.token.TokenService;
+import com.swmarastro.mykkumiserver.user.User;
+import com.swmarastro.mykkumiserver.user.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserService userService;
+    private final TokenService tokenService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+        boolean hasUserType = User.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasLoginAnnotation && hasUserType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String authorization = request.getHeader("Authorization");
+        if (authorization != null && authorization.startsWith("Bearer ")) { //TODO Bearer를 전에 토큰 줄때도 붙여서 줘야됐나?
+            String token = authorization.substring(7);
+            if(tokenService.isValidToken(token)) { //유효한 토큰인지 검증
+                UUID userUuid = tokenService.getUserUuidFromToken(token);
+                User user = userService.getUserByUuid(userUuid);
+                return user;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/LoginUserArgumentResolver.java
@@ -33,7 +33,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         String authorization = request.getHeader("Authorization");
-        if (authorization != null && authorization.startsWith("Bearer ")) { //TODO Bearer를 전에 토큰 줄때도 붙여서 줘야됐나?
+        if (authorization != null && authorization.startsWith("Bearer ")) {
             String token = authorization.substring(7);
             if(tokenService.isValidToken(token)) { //유효한 토큰인지 검증
                 UUID userUuid = tokenService.getUserUuidFromToken(token);

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/TokenService.java
@@ -30,7 +30,7 @@ public class TokenService {
      * refresh token으로 user의 access token 재발급
      */
     public String createNewAccessToken(String refreshToken) {
-        if (!isValidToken(refreshToken)) {
+        if (!isValidRefreshToken(refreshToken)) {
             throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
         }
         //토큰에서 유저 uuid 추출
@@ -56,7 +56,7 @@ public class TokenService {
     /**
      * 유효한 refresh token인지, 사용자는 실제로 존재하는지 검증
      */
-    public boolean isValidToken(String refreshToken) {
+    public boolean isValidRefreshToken(String refreshToken) {
         //유효한 토큰인지 확인
         if(!jwtProvider.validToken(refreshToken)) {
             throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
@@ -73,6 +73,21 @@ public class TokenService {
         //해당 유저 존재하는지 확인
         User user = userService.getUserByUuid(Uuid);
         return true;
+    }
+
+    /**
+     * 유효한 엑세스 토큰인지 검증
+     */
+    public boolean isValidToken(String token) {
+        //유효한 토큰인지 확인
+        if(!jwtProvider.validToken(token)) {
+            throw new CommonException(ErrorCode.INVALID_TOKEN, "유효하지 않은 토큰입니다.", "유효하지 않은 토큰입니다.");
+        }
+        return true;
+    }
+
+    public UUID getUserUuidFromToken(String token) {
+        return UUID.fromString(jwtProvider.getSubject(token));
     }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/global/config/S3Config.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.swmarastro.mykkumiserver.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final S3properties s3properties;
+
+    @Bean
+    public AmazonS3 AmazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(s3properties.getAccessKey(), s3properties.getSecretKey());
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(s3properties.getRegion())
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/config/S3properties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/config/S3properties.java
@@ -1,0 +1,19 @@
+package com.swmarastro.mykkumiserver.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class S3properties {
+
+    @Value("{$cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("{$cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("{$cloud.aws.region}")
+    private String region;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/config/WebConfig.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/config/WebConfig.java
@@ -1,0 +1,30 @@
+package com.swmarastro.mykkumiserver.global.config;
+
+import com.swmarastro.mykkumiserver.auth.LoginUserArgumentResolver;
+import com.swmarastro.mykkumiserver.auth.token.TokenService;
+import com.swmarastro.mykkumiserver.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserService userService;
+    private final TokenService tokenService;
+
+    @Bean
+    public LoginUserArgumentResolver loginUserArgumentResolver() {
+        return new LoginUserArgumentResolver(userService, tokenService);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver());
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
@@ -1,0 +1,25 @@
+package com.swmarastro.mykkumiserver.user;
+
+import com.swmarastro.mykkumiserver.auth.Login;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
+import com.swmarastro.mykkumiserver.user.dto.MeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UserController {
+
+    @GetMapping("/users/me")
+    public ResponseEntity<MeResponse> getMe(@Login User user) {
+        if (user == null) { //TODO service에서 해야될 일이 이 예외처리밖에 없어보이는데 service로 보내는 것이 나을지??
+            throw new CommonException(ErrorCode.INVALID_TOKEN, "로그인을 해주세요", "올바른 토큰이 아니거나 토큰이 존재하지 않습니다.");
+        }
+        MeResponse meResponse = MeResponse.of(user);
+        return ResponseEntity.ok(meResponse);
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
@@ -28,4 +28,5 @@ public class UserService {
     public Optional<User> getUserByEmailAndProvider(String email, OAuthProvider provider) {
         return userRepository.findByEmailAndProvider(email, provider);
     }
+
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/dto/MeResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/dto/MeResponse.java
@@ -1,0 +1,30 @@
+package com.swmarastro.mykkumiserver.user.dto;
+
+import com.swmarastro.mykkumiserver.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeResponse {
+
+    private String nickname;
+    private String email;
+    private String introduction;
+    private String profileImage;
+
+    public static MeResponse of(User user) {
+        if (user.getNickname() == null) {
+            return MeResponse.builder()
+                    .email(user.getEmail())
+                    .build();
+        }
+        return MeResponse.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .introduction(user.getIntroduction())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
+}
+


### PR DESCRIPTION
user_info 브랜치에서 <로그인된 유저 정보 조회>와 <유저 정보 업데이트>를 함께 pr 올리려다가 너무 길어져서 하나씩 나누어서 올립니다!

## 구현내용
### 1. 로그인된 유저 정보 조회 api
#### @Login 어노테이션
아래와 같이 @Login 어노테이션을 생성했습니다. 
```java
@Target(ElementType.PARAMETER)
@Retention(RetentionPolicy.RUNTIME)
public @interface Login {
}
```
용도는 아래와 같이 현재 로그인된 유저의 정보를 가져올 때 사용됩니다. 로그인된 유저가 있다면 User 객체를 넣어주고, 없다면 null이 들어갑니다. 유저 정보를 가져올 일이 앞으로도 많을 것이라 생각하여 간단히 로그인된 유저 정보를 가져올 수 있도록 했습니다. 
```java
@GetMapping("/users/me")
    public ResponseEntity<MeResponse> getMe(@Login User user) { ... }
```

### 2. S3 사진 업로드 util
후에 프로필사진 등록을 위한 S3 사진 업로드 기능을 만들었습니다.

## 고민사항
### 1. 필요할까?
로그인된 유저만 호출할 수 있는 api라면 이미 스프링 시큐리티의 필터에 걸리던지 하여 컨트롤러 단계까지 도달하지 못할 것 같은데, @Login User user를 통해 주입된 user가 null인지 확인하는 이 코드가 꼭 필요할지 의문입니다. 나중에 로그인된 유저, 아닌 유저를 한 api에서 구분해서 다른 역할을 수행하게 한다면 필요할 수도 있을것 같지만, 로그인된 유저정보 조회 api에서는 필요하지 않을 것 같고 여기까지 도달하지도 못할 것 같아 이 코드를 써야할지 의문입니다.
```java
if (user == null) { 
            throw new CommonException(ErrorCode.INVALID_TOKEN, "로그인을 해주세요", "올바른 토큰이 아니거나 토큰이 존재하지 않습니다.");
        }
```

### 2. controller에서 꼭 service를 호출해야할지 고민입니다.
현재 로그인된 유저의 정보를 가져오는 api인데, user가 이미 파라미터에 주입되어 있어서 MeResponse에 옮기기만 하면 됩니다. 할일이 user가 null일때 처리 정도일것 같은데 이 부분도 service를 만들어서 넘기는 것이 좋을지 고민입니다.
```java
@GetMapping("/users/me")
    public ResponseEntity<MeResponse> getMe(@Login User user) {
        if (user == null) { //TODO service에서 해야될 일이 이 예외처리밖에 없어보이는데 service로 보내는 것이 나을지??
            throw new CommonException(ErrorCode.INVALID_TOKEN, "로그인을 해주세요", "올바른 토큰이 아니거나 토큰이 존재하지 않습니다.");
        }
        MeResponse meResponse = MeResponse.of(user);
        return ResponseEntity.ok(meResponse);
    }
```
