### PR TITLE
KKUMI-38 user info 유저가 선택한 카테고리 업데이트

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/category/CategoryService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/CategoryService.java
@@ -1,0 +1,20 @@
+
+package com.swmarastro.mykkumiserver.category;
+
+import com.swmarastro.mykkumiserver.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final UserSubCategoryRepository userSubCategoryRepository;
+
+    //회원가입 시 생성됨, 카테고리 초기 null 상태
+    public UserSubCategory saveUserSubCategory(User user) {
+        UserSubCategory userSubCategory = UserSubCategory.of(user);
+        return userSubCategoryRepository.save(userSubCategory);
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/category/UserSubCategory.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/UserSubCategory.java
@@ -2,10 +2,20 @@ package com.swmarastro.mykkumiserver.category;
 
 import com.swmarastro.mykkumiserver.user.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserSubCategory {
 
     @Id
@@ -13,11 +23,32 @@ public class UserSubCategory {
     @Column(name = "user_sub_category")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sub_category_id", nullable = false)
-    private SubCategory subCategory;
+    private String subCategory;
+
+    public static String listToString(List<Long> categoryIds) {
+        return categoryIds.stream().map(Object::toString).collect(Collectors.joining(","));
+    }
+
+    public static List<Long> stringToList(String categoryString) {
+        return Arrays.stream(categoryString.split(","))
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+    }
+
+    public String updateSubCategory(List<Long> categoryIds) {
+        String categoryStr = listToString(categoryIds);
+        this.subCategory = categoryStr;
+        return categoryStr;
+    }
+
+    public static UserSubCategory of(User user) {
+        return UserSubCategory.builder()
+                .user(user)
+                .subCategory(null)
+                .build();
+    }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/category/UserSubCategoryRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/UserSubCategoryRepository.java
@@ -1,0 +1,6 @@
+package com.swmarastro.mykkumiserver.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSubCategoryRepository extends JpaRepository<UserSubCategory, Long> {
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/category/UserSubCategoryRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/UserSubCategoryRepository.java
@@ -1,6 +1,8 @@
 package com.swmarastro.mykkumiserver.category;
 
+import com.swmarastro.mykkumiserver.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserSubCategoryRepository extends JpaRepository<UserSubCategory, Long> {
+    UserSubCategory findByUser(User user);
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -27,6 +25,7 @@ public class User {
     private Long id;
     @Column(updatable = false, nullable = false, unique = true, columnDefinition = "BINARY(16)")
     private UUID uuid;
+    @Column(unique = true)
     private String nickname;
     @Column(nullable = false)
     private String email;
@@ -36,8 +35,8 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private OAuthProvider provider;
 
-    @OneToMany(mappedBy = "user")
-    private List<UserSubCategory> userSubCategories = new ArrayList<>();
+    @OneToOne(mappedBy = "user")
+    private UserSubCategory userSubCategories;
 
     public static User of(OAuthProvider provider, String email) {
         return User.builder()
@@ -47,7 +46,6 @@ public class User {
                 .build();
     }
 
-    //TODO <카테고리> 제외, 연관관계 메서드 사용?? 여기는 연관관계 주인이 아니라서 여기를 바꾼다고 DB에 반영되지는 않는다.
     public void updateUser(String nickname, String introduction, String profileImage) {
         if (nickname != null) {
             this.nickname = nickname;
@@ -59,4 +57,5 @@ public class User {
             this.profileImage = profileImage;
         }
     }
+
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
@@ -6,22 +6,20 @@ import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import com.swmarastro.mykkumiserver.user.dto.MeResponse;
 import com.swmarastro.mykkumiserver.user.dto.UpdateUserRequest;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
 
-    public UserController(UserService userService) {
-        this.userService = userService;
-    }
-
     @GetMapping("/users/me")
     public ResponseEntity<MeResponse> getMe(@Login User user) {
-        if (user == null) { //TODO service에서 해야될 일이 이 예외처리밖에 없어보이는데 service로 보내는 것이 나을지??
+        if (user == null) { //TODO service에서 해야될 일이 이 예외처리밖에 없어보이는데 service로 보내는 것이 나을지?? -> 카테고리 등 추가 가능성, 서비스로 빼기
             throw new CommonException(ErrorCode.INVALID_TOKEN, "로그인을 해주세요", "올바른 토큰이 아니거나 토큰이 존재하지 않습니다.");
         }
         MeResponse meResponse = MeResponse.of(user);
@@ -33,7 +31,7 @@ public class UserController {
         //TODO 닉네임 유효성 검사에서 걸렸을 때, 에러메시지 만들어주기
         if (loginUser == null) {
             throw new CommonException(ErrorCode.INVALID_TOKEN, "로그인을 해주세요", "올바른 토큰이 아니거나 토큰이 존재하지 않습니다.");
-        }
+        } //이거 filter에서 걸리게하고 얘 지우면 되는데, 필터에서 걸린애는 CommonException으로 못받을것.. 찾아보기..
         User user = userService.updateUser(loginUser, updateUserRequest);
         MeResponse meResponse = MeResponse.of(user);
         return ResponseEntity.ok(meResponse);

--- a/src/main/java/com/swmarastro/mykkumiserver/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/dto/UpdateUserRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Setter
@@ -17,5 +18,5 @@ public class UpdateUserRequest {
     private String nickname;
     private MultipartFile profileImage;
     private String introduction;
-    private List<Long> categories;
+    private List<Long> categoryIds = new ArrayList<>();
 }


### PR DESCRIPTION
## 구현내용
### 1. 유저 정보 업데이트 _ 카테고리
유저가 선택한 카테고리를 저장하는 부분을 구현했습니다.
#### DB
데이터베이스에 어떻게 저장할지 고민한결과, "1,2,3"과 같이 문자열로 저장하기로 했습니다.
따로 저장해도 따로 다뤄질 일이 없고, 오히려 여기저기 분산되어 있으면 복잡성을 더 증가시킬 것 같습니다.
아래와 같이 카테고리 테이블과 연결하지 않고 문자열로 처리하려고 합니다.
![스크린샷 2024-07-20 오후 12 23 14](https://github.com/user-attachments/assets/e4d0e76a-171e-4ca9-8f42-2dcdf4c9ad30)

#### 생성시점
현재 유저:유저가선택한카테고리 가 1:1입니다.
유저가 생성될때(회원가입) 유저가 선택한 카테고리 테이블에도 1:1 대응에 맞춰 레코드가 하나 생성됩니다.
이후 변경사항이 있으면 이 레코드의 sub_category 컬럼을 문자열로 업데이트해줄 예정입니다.

### 2. 닉네임 중복확인
현재 닉네임 중복확인을 UserService.java에서 아래와 같이 해주고 있습니다. 
```java
//중복된 닉네임일 때
if (nickname != null && isNicknameExists(nickname)) {
    throw new CommonException(ErrorCode.DUPLICATE_VALUE, "이미 사용 중인 닉네임입니다.", "이미 사용 중인 닉네임입니다.");
        }
```
하지만 이 검사를 거친 뒤에도 희박한 가능성이지만 동시에 같이 닉네임이 들어올 수 있습니다. 그래서 아래와 같이 DB에서 확인해 줄 수 있도록 했습니다. 그런데, 만약 DB 중복에 걸려서 닉네임을 변경할 수 없다면 유저에게 닉네임 중복이라는 메시지를 어떻게 내려줄지 고민중입니다. 또한 이런 부분 테스트도 정말 동시를 어떻게 만들지 잘 모르겠어서 찾아봐야할 것 같습니다.
```java
@Entity
public class User {
    ...
    @Column(unique = true)
    private String nickname;
    ...
}
```


## 고민사항
### 1. 프로필 이미지 지워주기
생각해보니 프로필 이미지가 다시 사용되지 않을것이고, 유저에게 프로필 이미지 히스토리가 보이지 않을 것임에도 계속 생성되기만 하고 지워주는 부분이 없어 차차 구현 예정입니다.

### 2. 에러처리
현재 정상 로직으로는 작동하지만, 에러처리에서 미흡한 부분이 있어 보완예정입니다.

### 3. 테스트
DB에서 닉네임 중복을 방지해주는 부분이 있었는데, 해당 부분 테스트는 어떻게 하는지 몰라서 조언을 구한 결과, 멘토님께서 @DataJpaTest를 찾아보라고 말씀해주셨습니다. 신청한 테스트 강의 등을 참고하여 공부할 예정입니다.
