### PR TITLE
KKUMI-42 apple login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,22 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    //bouncycastle
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+
+    // Jackson for JSON processing
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
+
+    // Nimbus JOSE + JWT for JWT processing
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.11.1'
+
+    // json-simple for JSON processing
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/AppleProperties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/AppleProperties.java
@@ -1,0 +1,28 @@
+package com.swmarastro.mykkumiserver.auth;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class AppleProperties {
+
+    @Value("${spring.security.oauth2.client.registration.apple.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.apple.key-id}")
+    private String keyId;
+
+    @Value("${spring.security.oauth2.client.registration.apple.team-id}")
+    private String teamId;
+
+    @Value("${spring.security.oauth2.client.registration.apple.private-key}")
+    private String privateKey;
+
+    @Value("${spring.security.oauth2.client.registration.apple.grant-type}")
+    private String grantType;
+
+    @Value("${spring.security.oauth2.client.registration.apple.audience}")
+    private String audience;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
@@ -1,9 +1,6 @@
 package com.swmarastro.mykkumiserver.auth;
 
-import com.swmarastro.mykkumiserver.auth.dto.NewAccessTokenRequest;
-import com.swmarastro.mykkumiserver.auth.dto.NewAccessTokenResponse;
-import com.swmarastro.mykkumiserver.auth.dto.SigninRequest;
-import com.swmarastro.mykkumiserver.auth.dto.SigninResponse;
+import com.swmarastro.mykkumiserver.auth.dto.*;
 import com.swmarastro.mykkumiserver.auth.service.AuthService;
 import com.swmarastro.mykkumiserver.auth.token.TokenService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +21,13 @@ public class AuthController {
     @PostMapping("/signin/kakao")
     public ResponseEntity<SigninResponse> signinKakao(@RequestBody SigninRequest request) {
         SigninResponse signinResponse = authService.signin(request, OAuthProvider.KAKAO);
+        return ResponseEntity.ok()
+                .body(signinResponse);
+    }
+
+    @PostMapping("/signin/apple")
+    public ResponseEntity<SigninResponse> signinApple(@RequestBody SigninRequest request) {
+        SigninResponse signinResponse = authService.signin(request, OAuthProvider.APPLE);
         return ResponseEntity.ok()
                 .body(signinResponse);
     }

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/AuthController.java
@@ -19,14 +19,14 @@ public class AuthController {
     private final TokenService tokenService;
 
     @PostMapping("/signin/kakao")
-    public ResponseEntity<SigninResponse> signinKakao(@RequestBody SigninRequest request) {
+    public ResponseEntity<SigninResponse> signinKakao(@RequestBody KakaoSigninRequest request) {
         SigninResponse signinResponse = authService.signin(request, OAuthProvider.KAKAO);
         return ResponseEntity.ok()
                 .body(signinResponse);
     }
 
     @PostMapping("/signin/apple")
-    public ResponseEntity<SigninResponse> signinApple(@RequestBody SigninRequest request) {
+    public ResponseEntity<SigninResponse> signinApple(@RequestBody AppleSigninRequest request) {
         SigninResponse signinResponse = authService.signin(request, OAuthProvider.APPLE);
         return ResponseEntity.ok()
                 .body(signinResponse);

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/AppleSigninRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/AppleSigninRequest.java
@@ -1,0 +1,12 @@
+package com.swmarastro.mykkumiserver.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AppleSigninRequest extends SigninRequest {
+    private String authorizationCode;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/KakaoSigninRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/KakaoSigninRequest.java
@@ -1,0 +1,14 @@
+package com.swmarastro.mykkumiserver.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class KakaoSigninRequest extends SigninRequest{
+
+    private String refreshToken;
+    private String accessToken;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninRequest.java
@@ -1,15 +1,4 @@
 package com.swmarastro.mykkumiserver.auth.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@AllArgsConstructor
-@NoArgsConstructor
-@Getter
 public class SigninRequest {
-
-    private String refreshToken;
-    private String accessToken;
-    private String authorizationCode;
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/dto/SigninRequest.java
@@ -11,4 +11,5 @@ public class SigninRequest {
 
     private String refreshToken;
     private String accessToken;
+    private String authorizationCode;
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/service/AppleService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/service/AppleService.java
@@ -1,0 +1,130 @@
+package com.swmarastro.mykkumiserver.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
+import org.json.simple.parser.JSONParser;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.swmarastro.mykkumiserver.auth.AppleProperties;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.json.simple.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.security.PrivateKey;
+import java.security.Security;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class AppleService {
+
+    private final JSONParser jsonParser = new JSONParser();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final AppleProperties appleProperties;
+
+    public String getAppleInfo(String authorizationCode) {
+        String clientSecret = generateClientSecret();
+        String userId = "";
+        String email  = "";
+        String accessToken = "";
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Content-type", "application/x-www-form-urlencoded");
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type"   , appleProperties.getGrantType());
+            params.add("client_id"    , appleProperties.getClientId());
+            params.add("client_secret", clientSecret);
+            params.add("code"         , authorizationCode);
+            params.add("redirect_uri" , "https://dev-api.mykkumi.com");
+
+            RestTemplate restTemplate = new RestTemplate();
+            HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(params, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://appleid.apple.com/auth/token",
+                    HttpMethod.POST,
+                    httpEntity,
+                    String.class
+            );
+
+            JSONObject jsonObj = (JSONObject) jsonParser.parse(response.getBody());
+            accessToken = String.valueOf(jsonObj.get("access_token"));
+
+            //ID TOKEN을 통해 회원 고유 식별자 받기
+            SignedJWT signedJWT = SignedJWT.parse(String.valueOf(jsonObj.get("id_token")));
+            JWTClaimsSet getPayload = signedJWT.getJWTClaimsSet();
+
+            String payloadString = objectMapper.writeValueAsString(getPayload.toJSONObject());
+            JSONObject payload = objectMapper.readValue(payloadString, JSONObject.class);
+
+            userId = String.valueOf(payload.get("sub"));
+            email  = String.valueOf(payload.get("email"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "로그인할 수 없습니다.", "애플 OAuth 정보를 가져오는 데 실패했습니다.");
+            //TODO 클라이언트가 준 토큰이 잘못되었는지, 만에 하나 애플 인증 서버가 장애인지 애플에서 주는 코드로 구분해서 에러를 뿌려줘야 할 것 같다
+        }
+
+        AppleUserInfoDto appleDTO = AppleUserInfoDto.builder()
+                .id(userId)
+                .token(accessToken)
+                .email(email).build();
+
+        return appleDTO.getEmail();
+    }
+
+
+    /**
+     * apple client secret 생성하는 메서드
+     */
+    private String generateClientSecret() {
+
+        LocalDateTime expiration = LocalDateTime.now().plusMinutes(5);
+
+        return Jwts.builder()
+                .setHeaderParam(JwsHeader.KEY_ID, appleProperties.getKeyId())
+                .setIssuer(appleProperties.getTeamId())
+                .setAudience(appleProperties.getAudience())
+                .setSubject(appleProperties.getClientId())
+                .setExpiration(Date.from(expiration.atZone(ZoneId.systemDefault()).toInstant()))
+                .setIssuedAt(new Date())
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+                .compact();
+    }
+
+    /**
+     * String에서 Private key로 변환하는 메서드
+     */
+    private PrivateKey getPrivateKey() {
+
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+
+        try {
+            byte[] privateKeyBytes = Base64.getDecoder().decode(appleProperties.getPrivateKey());
+            PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKeyBytes);
+            return converter.getPrivateKey(privateKeyInfo);
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "로그인할 수 없습니다.", "String을 private key로 변환하는 데 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/service/AppleUserInfoDto.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/service/AppleUserInfoDto.java
@@ -1,0 +1,13 @@
+package com.swmarastro.mykkumiserver.auth.service;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class AppleUserInfoDto {
+    //TODO email 제외 쓸 일 없으면 지우기
+    private String id;
+    private String token;
+    private String email;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/service/AuthService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/service/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService {
         if (userOptional.isPresent()) { //가입된 사용자
             return userOptional.get();
         } else { //신규가입, 사용자 회원가입 시키기
-            return userService.saveUser(OAuthProvider.KAKAO, email);
+            return userService.saveUser(oAuthProvider, email);
         }
     }
 

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/service/AuthService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/service/AuthService.java
@@ -20,12 +20,25 @@ import java.util.Optional;
 public class AuthService {
 
     private final KakaoService kakaoService;
+    private final AppleService appleService;
     private final UserService userService;
     private final TokenService tokenService;
 
     public SigninResponse signin(SigninRequest request, OAuthProvider oAuthProvider) {
+
+        //필요한 토큰 가져오기
+        String token = null;
+        if (oAuthProvider == OAuthProvider.KAKAO) { //카카오는 엑세스 토큰
+            token = request.getAccessToken();
+        } else if (oAuthProvider == OAuthProvider.APPLE) { //애플은 인가코드
+            token = request.getAuthorizationCode();
+        }
+        if (token == null) {
+            throw new CommonException(ErrorCode.NOT_FOUND, "로그인할 수 없습니다.", "토큰을 찾을 수 없습니다.");
+        }
+
         //사용자 이메일 받아오기
-        String email = getEmail(request.getAccessToken(), oAuthProvider);
+        String email = getEmail(token, oAuthProvider);
         //유저 찾기
         User user = getUserByEmailAndProvider(email, oAuthProvider);
         //우리 서비스 토큰 발급
@@ -50,9 +63,11 @@ public class AuthService {
         }
     }
 
-    String getEmail(String accessToken, OAuthProvider oAuthProvider) {
+    String getEmail(String token, OAuthProvider oAuthProvider) {
         if (oAuthProvider == OAuthProvider.KAKAO) {
-            return kakaoService.getKakaoInfo(accessToken);
+            return kakaoService.getKakaoInfo(token);
+        } else if (oAuthProvider == OAuthProvider.APPLE) {
+            return appleService.getAppleInfo(token);
         }
         throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다. 다시 시도해주세요.", "OAuth2 사용자 정보를 가져오는데 실패했습니다.");
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,13 @@ spring:
             client-name: Kakao
             authorization-grant-type: authorization_code
             redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+          apple:
+            grant-type: authorization_code
+            client-id: ${apple_client_id}
+            key-id: ${apple_key_id}
+            team-id: ${apple_team_id}
+            audience: https://appleid.apple.com
+            private-key: ${apple_private_key}
 
 server:
   port: 8080


### PR DESCRIPTION
## 구현내용
### 1. 애플 로그인
애플 로그인을 구현했습니다. 그동안 해봤던 구글, 카카오 로그인과 조금 달랐습니다.
<img width="772" alt="스크린샷 2024-07-22 오전 2 25 03" src="https://github.com/user-attachments/assets/d616d36b-d208-4185-9b7a-236ba00c164f">
1. 클라이언트로부터 authorization code 받아오기
2. client secret을 서버에서 생성
3. 생성한 client secret과 여러 정보들로 유저 정보 요청

client secret을 직접 생성해서 쓴다는 게 특이한 점이었던 것 같습니다.

## 고민사항
### 1. SigninRequest를 쪼개야할까?
카카오 로그인에서는 클라이언트로부터 accessToken, refreshToken을 받아오는데,
애플 로그인에서는 authorization code를 받게되어 기존의 token들만 있던 dto를 변경해야할지 고민했습니다.
굳이 파일을 더 늘릴 필요가 있을까 싶어 아래와 같이 authorizationCode만 추가해주었습니다.
```java
public class SigninRequest {

    private String refreshToken;
    private String accessToken;
    private String authorizationCode;
}
```

AuthService 코드에서 아래와 같이 분리해서 토큰이라는 이름으로 가져왔습니다.
```java
//필요한 토큰 가져오기
String token = null;
if (oAuthProvider == OAuthProvider.KAKAO) { //카카오는 엑세스 토큰
    token = request.getAccessToken();
} else if (oAuthProvider == OAuthProvider.APPLE) { //애플은 인가코드
    token = request.getAuthorizationCode();
}
```

### 2. 같은 이메일 같은 유저?
여러 OAuth를 통해 가져온 유저의 이메일이 같다면 같은 기존 유저로 볼지 고민입니다.
현재 구현된 모습을 생각해보면, 이메일로 유저가 우리서비스에 가입되어 있는지 판단하고 있습니다. 그 결과, 애플로 로그인하여 사용하던 유저가 처음으로 카카오로 로그인을 시도했을 때, 이메일이 같아서 그냥 기존 같은 유저로 인식합니다. 한개의 이메일을 여러 사람이 사용할 수는 없을 것 같아 괜찮을 것 같기도합니다. 하지만, 서비스 사용자로서 여러 서비스를 사용했던 걸 생각해보면 **네이버로 로그인되어 있습니다. 카카오로도 연결하시겠습니까?** 같은 알림이 떴던 것 같아 고민중입니다. 이메일이 같으면 어차피 같은 유저인데 왜 한번더 연결하겠냐고 확인하는지 찾아봐야 할 것 같습니다.
