### PR TITLE
KKUMI-60 #37 유저 닉네임형식 올바르지 않을때 예외처리

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.swmarastro.mykkumiserver.global.exception;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @Getter
 @Builder
@@ -26,6 +27,14 @@ public class ErrorResponse {
                 .errorCode(ErrorCode.INTERNAL_SERVER_ERROR.getErrorCodeName())
                 .message("알 수 없는 에러입니다. 잠시 후 시도해주세요.")
                 .detail("서버 에러입니다.")
+                .build();
+    }
+
+    public static ErrorResponse from(MethodArgumentNotValidException e) {
+        return ErrorResponse.builder()
+                .errorCode(ErrorCode.INVALID_VALUE.getErrorCodeName())
+                .message(e.getFieldError().getDefaultMessage())
+                .detail(e.getFieldError().getField()+" '"+e.getFieldError().getRejectedValue()+"' 사용할 수 없습니다."+e.getFieldError().getDefaultMessage())
                 .build();
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,13 @@
 package com.swmarastro.mykkumiserver.global.exception;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
@@ -19,5 +23,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.from(e));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        ErrorResponse error = ErrorResponse.from(ex);
+        return ResponseEntity.status(status)
+                .body(error);
     }
 }


### PR DESCRIPTION
서비스 자체 에러로 응답되도록 수정했습니다.

## 구현내용
### 1. 유저 닉네임 길이가 짧을 때 예외처리
```json
{
    "errorCode": "INVALID_VALUE",
    "message": "닉네임은 3자 이상 16자 이하이어야 합니다.",
    "detail": "nickname '닉' 사용할 수 없습니다.닉네임은 3자 이상 16자 이하이어야 합니다."
}
```

### 2. 유저 닉네임에 허용되지 않은 문자가 들어갔을 때 예외처리
```json
{
    "errorCode": "INVALID_VALUE",
    "message": "닉네임은 숫자, 알파벳, '.', '_', '-', 한글만 포함할 수 있습니다.",
    "detail": "nickname '닉네임#' 사용할 수 없습니다.닉네임은 숫자, 알파벳, '.', '_', '-', 한글만 포함할 수 있습니다."
}
```
## 고민사항
### 1. 어떤 에러메시지를 유저에게 보내줘야하는가?
예외를 발생시키는 게 내가 손수 짠 코드가 아니다보니 어떤 에러 메시지를 보내줘야할지 고민이었습니다.
message는 누가봐도 아래 FieldError의 DefaultMessage를 보내주면될것 같은데, detail은 고민하다가 어떤 닉네임이 안된다고 한번 더 추가해줬습니다.
아래 코드를 적을때 FieldError이 null일수도 있다고 경고가 뜹니다. 아직 그런경우를 마주치지 못해서 그대로 두긴했으나 그런경우에는 무슨 메시지를 보내야하는지 고민입니다.
```java
e.getFieldError().getDefaultMessage()
```