### PR TITLE
KKUMI-58 presigned url image upload

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/global/config/S3properties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/config/S3properties.java
@@ -20,4 +20,11 @@ public class S3properties {
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
+
+    @Value("${aws.s3.post-image-path}")
+    private String postImagePath;
+
+    @Value("${aws.s3.profile-image-path}")
+    private String profileImagePath;
 }
+

--- a/src/main/java/com/swmarastro/mykkumiserver/global/util/AwsS3Utils.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/util/AwsS3Utils.java
@@ -2,13 +2,17 @@ package com.swmarastro.mykkumiserver.global.util;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.swmarastro.mykkumiserver.global.config.S3properties;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Calendar;
 import java.util.Date;
@@ -48,5 +52,32 @@ public class AwsS3Utils {
         calendar.setTime(new Date());
         calendar.add(Calendar.MINUTE, 10); //10분간 유효함
         return amazonS3.generatePresignedUrl(bucketName, filePath, calendar.getTime(), HttpMethod.PUT).toString();
+    }
+
+    public Boolean isValidUrl(String url, String hashCode) {
+        try {
+            String objectKey = getObjectKeyFromUrl(url);
+
+            // 업로드된 파일의 메타데이터를 가져옴
+            GetObjectMetadataRequest metadataRequest = new GetObjectMetadataRequest(s3properties.getBucket(), objectKey);
+            ObjectMetadata metadata = amazonS3.getObjectMetadata(metadataRequest);
+
+            // S3에서 반환된 ETag와 클라이언트가 제공한 MD5 해시를 비교
+            String uploadedETag = metadata.getETag();
+            return uploadedETag.equals(hashCode);
+        } catch (Exception e) {
+            //TODO 무슨 에러가 어떻게 생길 줄 알고 에러를 내릴까
+            return false;
+        }
+    }
+
+    private String getObjectKeyFromUrl(String url) {
+        try {
+            URL urlObj = new URL(url);
+            // URL에서 경로 부분을 가져오고 첫 번째 슬래시를 제거하여 반환
+            return urlObj.getPath().substring(1);
+        } catch (MalformedURLException e) {
+            throw new CommonException(ErrorCode.INVALID_VALUE, "url 형식이 올바르지 않습니다.", "url 형식이 올바르지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/global/util/AwsS3Utils.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/util/AwsS3Utils.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.global.util;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.swmarastro.mykkumiserver.global.config.S3properties;
@@ -9,6 +10,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.UUID;
 
 @Component
@@ -35,5 +38,15 @@ public class AwsS3Utils {
         objMeta.setContentLength(file.getInputStream().available());
         amazonS3.putObject(s3properties.getBucket(), s3FileName, file.getInputStream(), objMeta);
         return s3FileName;
+    }
+
+    /**
+     * preSignedUrl 발급 _ 10분간 유효
+     */
+    public String generatePreSignedUrl(String filePath, String bucketName) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.MINUTE, 10); //10분간 유효함
+        return amazonS3.generatePresignedUrl(bucketName, filePath, calendar.getTime(), HttpMethod.PUT).toString();
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/global/util/Base64Utils.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/util/Base64Utils.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.swmarastro.mykkumiserver.global.exception.CommonException;
 import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import static java.util.Base64.*;
 

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
@@ -2,16 +2,15 @@ package com.swmarastro.mykkumiserver.post;
 
 import com.swmarastro.mykkumiserver.post.dto.PostImagePreSignedUrlResponse;
 import com.swmarastro.mykkumiserver.post.dto.PostListResponse;
+import com.swmarastro.mykkumiserver.post.dto.ValidatePostImageUrlRequest;
+import com.swmarastro.mykkumiserver.post.dto.ValidatePostImageUrlResponse;
 import com.swmarastro.mykkumiserver.post.service.PostImageService;
 import com.swmarastro.mykkumiserver.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "posts", description = "포스트 API")
 @RestController
@@ -39,4 +38,12 @@ public class PostController {
         PostImagePreSignedUrlResponse postImagePreSignedUrlResponse = PostImagePreSignedUrlResponse.of(url);
         return ResponseEntity.ok(postImagePreSignedUrlResponse);
     }
+
+    @PostMapping("/posts/imageUrl/validate")
+    public ResponseEntity<ValidatePostImageUrlResponse> validatePostImageUrl(@RequestBody ValidatePostImageUrlRequest request) {
+        Boolean isValid = postImageService.validatePostImageUrl(request);
+        ValidatePostImageUrlResponse validatePostImageUrlResponse = ValidatePostImageUrlResponse.of(isValid);
+        return ResponseEntity.ok(validatePostImageUrlResponse);
+    }
+
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.post;
 
+import com.swmarastro.mykkumiserver.post.dto.PostImagePreSignedUrlResponse;
 import com.swmarastro.mykkumiserver.post.dto.PostListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
+    private final PostImageService postImageService;
 
     /**
      * 홈화면 무한스크롤 포스트, 일단 모든 카테고리 최신순
@@ -27,5 +29,12 @@ public class PostController {
     public ResponseEntity<PostListResponse> getPosts(@RequestParam(required = false) String cursor, @RequestParam(required = false, defaultValue = "5") Integer limit) {
         PostListResponse infiniteScrollPosts = postService.getInfiniteScrollPosts(cursor, limit);
         return ResponseEntity.ok(infiniteScrollPosts);
+    }
+
+    @GetMapping("/posts/preSignedUrl")
+    public ResponseEntity<PostImagePreSignedUrlResponse> getPostImagePreSignedUrl(@RequestParam String extension) {
+        String url = postImageService.generatePostImagePreSignedUrl(extension);
+        PostImagePreSignedUrlResponse postImagePreSignedUrlResponse = PostImagePreSignedUrlResponse.of(url);
+        return ResponseEntity.ok(postImagePreSignedUrlResponse);
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
@@ -2,6 +2,8 @@ package com.swmarastro.mykkumiserver.post;
 
 import com.swmarastro.mykkumiserver.post.dto.PostImagePreSignedUrlResponse;
 import com.swmarastro.mykkumiserver.post.dto.PostListResponse;
+import com.swmarastro.mykkumiserver.post.service.PostImageService;
+import com.swmarastro.mykkumiserver.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostImageService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostImageService.java
@@ -1,0 +1,24 @@
+package com.swmarastro.mykkumiserver.post;
+
+import com.swmarastro.mykkumiserver.global.config.S3properties;
+import com.swmarastro.mykkumiserver.global.util.AwsS3Utils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PostImageService {
+
+    private final AwsS3Utils awsS3Utils;
+    private final S3properties s3properties;
+
+    public String generatePostImagePreSignedUrl(String extension) {
+        String filePath = s3properties.getPostImagePath() +
+                UUID.randomUUID() +
+                "." +
+                extension;
+        return awsS3Utils.generatePreSignedUrl(filePath, s3properties.getBucket());
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostImagePreSignedUrlResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostImagePreSignedUrlResponse.java
@@ -1,0 +1,17 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PostImagePreSignedUrlResponse {
+
+    private String url;
+
+    public static PostImagePreSignedUrlResponse of(String url) {
+        return PostImagePreSignedUrlResponse.builder()
+                .url(url)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/ValidatePostImageUrlRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/ValidatePostImageUrlRequest.java
@@ -1,0 +1,10 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ValidatePostImageUrlRequest {
+
+    private String hashCode;
+    private String url;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/ValidatePostImageUrlResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/ValidatePostImageUrlResponse.java
@@ -1,0 +1,17 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ValidatePostImageUrlResponse {
+
+    private Boolean isValid;
+
+    public static ValidatePostImageUrlResponse of(boolean isValid) {
+        return ValidatePostImageUrlResponse.builder()
+                .isValid(isValid)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/service/PostImageService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/service/PostImageService.java
@@ -2,6 +2,7 @@ package com.swmarastro.mykkumiserver.post.service;
 
 import com.swmarastro.mykkumiserver.global.config.S3properties;
 import com.swmarastro.mykkumiserver.global.util.AwsS3Utils;
+import com.swmarastro.mykkumiserver.post.dto.ValidatePostImageUrlRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,5 +21,9 @@ public class PostImageService {
                 "." +
                 extension;
         return awsS3Utils.generatePreSignedUrl(filePath, s3properties.getBucket());
+    }
+
+    public Boolean validatePostImageUrl(ValidatePostImageUrlRequest request) {
+        return awsS3Utils.isValidUrl(request.getUrl(), request.getHashCode());
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/service/PostImageService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/service/PostImageService.java
@@ -1,4 +1,4 @@
-package com.swmarastro.mykkumiserver.post;
+package com.swmarastro.mykkumiserver.post.service;
 
 import com.swmarastro.mykkumiserver.global.config.S3properties;
 import com.swmarastro.mykkumiserver.global.util.AwsS3Utils;

--- a/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
@@ -1,8 +1,10 @@
-package com.swmarastro.mykkumiserver.post;
+package com.swmarastro.mykkumiserver.post.service;
 
 import com.swmarastro.mykkumiserver.global.exception.CommonException;
 import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import com.swmarastro.mykkumiserver.global.util.Base64Utils;
+import com.swmarastro.mykkumiserver.post.PostLatestCursor;
+import com.swmarastro.mykkumiserver.post.PostRepository;
 import com.swmarastro.mykkumiserver.post.domain.Post;
 import com.swmarastro.mykkumiserver.post.dto.PostDto;
 import com.swmarastro.mykkumiserver.post.dto.PostListResponse;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,3 +78,8 @@ springdoc:
 jwt:
   issuer: ${jwt_issuer}
   secret_key: ${jwt_secret_key}
+
+aws:
+  s3:
+    post-image-path: ${s3_post_image_path}
+    profile-image-path: ${s3_profile_image_path}


### PR DESCRIPTION
## 구현내용
### 1. presigned url 발급받는 api
이미지 업로드 시 서버를 거치면 서버 부하가 심해질 것이라고 멘토님께서 조언해주셔서 presigned url을 찾아봤습니다.
presigned url을 발급받는 api를 구현했습니다.

### 2. S3 url 유효한지 검증하는 api 
혼자 테스트를 해보다보니 이미지가 제대로 s3에 저장되지 않았는데도 200 응답만이 오는 것을 발견했습니다.
그래서 이미지를 올리고나서 url이 유효한지 판단해주는 api를 만들어봤습니다.
아래와 같이 이미지의 MD5 해시코드와 url을 보내면, S3에서 해당 url의 ETag와 클라이언트가 전달한 해시코드를 비교했습니다.
```json
{
    "hashCode": "947438798s9d71791d4438ufsd3",
    "url": "https://bucket.s3.ap-northeast-2.amazonaws.com/5cdfe83-796e-4f3f-84f2-46skd273db521.jpeg"
}
```
같다면 아래와 같이 응답이 내려오도록 했습니다.
```json
{
    "isValid": true
}
```

## 고민사항
### 1. 어떻게 제대로 업로드되었는지 확인할 것인가?
presigned url을 사용했을 때, 파일이 제대로 올라가지 않았더라도 200 응답을 내려주는 것을 발견했습니다.
그래서 제대로 파일이 업로드 되었는지 확인해주는 api를 따로 구현했습니다.
클라이언트에서 이미지를 업로드한 후, 서버에 한번 더 검증하는 api를 호출하면 될 것 같습니다.

### 2. S3에 저장될 이미지 파일 이름
파일 이름을 일단 그냥 uuid로 해놨는데 괜찮은 방법일지 궁금합니다.
