### PR TITLE
KKUMI-61 post registration

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
@@ -2,7 +2,9 @@ package com.swmarastro.mykkumiserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MykkumiServerApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/auth/token/RefreshToken.java
@@ -1,11 +1,10 @@
 package com.swmarastro.mykkumiserver.auth.token;
 
+import com.swmarastro.mykkumiserver.global.BaseEntity;
 import com.swmarastro.mykkumiserver.user.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
 
-import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
 
@@ -14,7 +13,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken {
+public class RefreshToken extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,16 +30,12 @@ public class RefreshToken {
     private String refreshToken;
     private Date tokenExpiry;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
     public static RefreshToken of(User user, String token, Date expiry, UUID uuid) {
         return RefreshToken.builder()
                 .user(user)
                 .refreshToken(token)
                 .uuid(uuid)
                 .tokenExpiry(expiry)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/banner/Banner.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/banner/Banner.java
@@ -1,11 +1,12 @@
 package com.swmarastro.mykkumiserver.banner;
 
+import com.swmarastro.mykkumiserver.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
 @Getter
 @Entity
-public class Banner {
+public class Banner extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swmarastro/mykkumiserver/category/CategoryService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/CategoryService.java
@@ -5,6 +5,8 @@ import com.swmarastro.mykkumiserver.category.domain.Category;
 import com.swmarastro.mykkumiserver.category.domain.SubCategory;
 import com.swmarastro.mykkumiserver.category.domain.UserSubCategory;
 import com.swmarastro.mykkumiserver.category.dto.CategoryDto;
+import com.swmarastro.mykkumiserver.global.exception.CommonException;
+import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import com.swmarastro.mykkumiserver.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ import java.util.stream.Collectors;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final SubCategoryRepository subCategoryRepository;
     private final UserSubCategoryRepository userSubCategoryRepository;
 
     //회원가입 시 생성됨, 카테고리 초기 null 상태
@@ -43,6 +46,11 @@ public class CategoryService {
                 })
                 .collect(Collectors.toList());
 
+    }
+
+    public SubCategory getSubCategoryById(Long id) {
+        return subCategoryRepository.findById(id)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_VALUE, "해당 카테고리를 찾을 수 없습니다.", "해당 id의 카테고리가 존재하지 않습니다."));
     }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/category/SubCategoryRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/SubCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.swmarastro.mykkumiserver.category;
+
+import com.swmarastro.mykkumiserver.category.domain.SubCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/category/domain/Category.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/domain/Category.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.category.domain;
 
+import com.swmarastro.mykkumiserver.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -8,7 +9,7 @@ import java.util.List;
 
 @Getter
 @Entity
-public class Category {
+public class Category extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swmarastro/mykkumiserver/category/domain/SubCategory.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/domain/SubCategory.java
@@ -1,5 +1,6 @@
 package com.swmarastro.mykkumiserver.category.domain;
 
+import com.swmarastro.mykkumiserver.global.BaseEntity;
 import com.swmarastro.mykkumiserver.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import java.util.List;
 
 @Getter
 @Entity
-public class SubCategory {
+public class SubCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swmarastro/mykkumiserver/category/domain/UserSubCategory.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/category/domain/UserSubCategory.java
@@ -1,11 +1,9 @@
 package com.swmarastro.mykkumiserver.category.domain;
 
+import com.swmarastro.mykkumiserver.global.BaseEntity;
 import com.swmarastro.mykkumiserver.user.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,9 +12,9 @@ import java.util.stream.Collectors;
 @Getter
 @Entity
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class UserSubCategory {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSubCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/swmarastro/mykkumiserver/global/BaseEntity.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.swmarastro.mykkumiserver.global;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED),
 
+    //403 FORBIDDEN
+    ACCESS_DENIED(HttpStatus.FORBIDDEN),
+
     // 404 NOT FOUND
     NOT_FOUND(HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
@@ -1,11 +1,10 @@
 package com.swmarastro.mykkumiserver.post;
 
-import com.swmarastro.mykkumiserver.post.dto.PostImagePreSignedUrlResponse;
-import com.swmarastro.mykkumiserver.post.dto.PostListResponse;
-import com.swmarastro.mykkumiserver.post.dto.ValidatePostImageUrlRequest;
-import com.swmarastro.mykkumiserver.post.dto.ValidatePostImageUrlResponse;
+import com.swmarastro.mykkumiserver.auth.Login;
+import com.swmarastro.mykkumiserver.post.dto.*;
 import com.swmarastro.mykkumiserver.post.service.PostImageService;
 import com.swmarastro.mykkumiserver.post.service.PostService;
+import com.swmarastro.mykkumiserver.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +43,12 @@ public class PostController {
         Boolean isValid = postImageService.validatePostImageUrl(request);
         ValidatePostImageUrlResponse validatePostImageUrlResponse = ValidatePostImageUrlResponse.of(isValid);
         return ResponseEntity.ok(validatePostImageUrlResponse);
+    }
+
+    @PostMapping("/posts")
+    public ResponseEntity<RegisterPostResponse> registerPost(@Login User user, @RequestBody RegisterPostRequest request) {
+        Long savedPostId = postService.registerPost(user, request.getSubCategoryId(), request.getContent(), request.getImages());
+        return ResponseEntity.ok().body(RegisterPostResponse.of(savedPostId));
     }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
@@ -51,4 +51,9 @@ public class PostController {
         return ResponseEntity.ok().body(RegisterPostResponse.of(savedPostId));
     }
 
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<Void> deletePost(@Login User user, @PathVariable Long postId) {
+        postService.deletePost(user, postId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/domain/Pin.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/domain/Pin.java
@@ -1,0 +1,39 @@
+package com.swmarastro.mykkumiserver.post.domain;
+
+import com.swmarastro.mykkumiserver.global.BaseEntity;
+import com.swmarastro.mykkumiserver.product.Product;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pin_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_image_id", nullable = false)
+    private PostImage postImage;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    private Double positionX;
+    private Double positionY;
+
+    public static Pin of(PostImage postImage, Product product, Double positionX, Double positionY) {
+        return Pin.builder()
+                .postImage(postImage)
+                .product(product)
+                .positionX(positionX)
+                .positionY(positionY)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/domain/Post.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/domain/Post.java
@@ -1,32 +1,32 @@
 package com.swmarastro.mykkumiserver.post.domain;
 
 import com.swmarastro.mykkumiserver.category.domain.SubCategory;
+import com.swmarastro.mykkumiserver.global.BaseEntity;
+import com.swmarastro.mykkumiserver.post.richtext.PostContentObject;
 import com.swmarastro.mykkumiserver.user.User;
 import jakarta.persistence.*;
-import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
 @Entity
-public class Post {
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
     private Long id;
-    private String content;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+    @Column(columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<PostContentObject> content;
     private Boolean isDeleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -37,13 +37,31 @@ public class Post {
     @JoinColumn(name = "sub_category_id", nullable = false)
     private SubCategory subCategory;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostImage> postImages = new ArrayList<>();
 
     public List<String> getPostImageUrls() {
         return postImages.stream()
                 .map(PostImage::getImageUrl)
                 .collect(Collectors.toList());
+    }
+
+    public static Post of(List<PostContentObject> content, User user, SubCategory subCategory, List<PostImage> postImages) {
+        Post post = Post.builder()
+                .content(content)
+                .user(user)
+                .subCategory(subCategory)
+                .postImages(postImages)
+                .isDeleted(false)
+                .build();
+
+        postImages.forEach(postImage -> postImage.addPost(post)); // Post 설정
+
+        return post;
+    }
+
+    public void deletePost() {
+        this.isDeleted = true;
     }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/domain/PostImage.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/domain/PostImage.java
@@ -1,11 +1,18 @@
 package com.swmarastro.mykkumiserver.post.domain;
 
+import com.swmarastro.mykkumiserver.global.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
-public class PostImage {
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,4 +24,24 @@ public class PostImage {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
+
+    private Long orderList;
+
+    @OneToMany(mappedBy = "postImage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Pin> pins = new ArrayList<>();
+
+    public static PostImage of(String url, Long orderList) {
+        return PostImage.builder()
+                .imageUrl(url)
+                .orderList(orderList)
+                .build();
+    }
+
+    public void addPins(List<Pin> pins) {
+        this.pins = pins;
+    }
+
+    public void addPost(Post post) {
+        this.post = post;
+    }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/PinDto.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/PinDto.java
@@ -1,0 +1,11 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PinDto {
+
+    private Double positionX;
+    private Double positionY;
+    private ProductInfoDto productInfo;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostDto.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostDto.java
@@ -1,6 +1,7 @@
 package com.swmarastro.mykkumiserver.post.dto;
 
 import com.swmarastro.mykkumiserver.post.domain.Post;
+import com.swmarastro.mykkumiserver.post.richtext.PostContentObject;
 import com.swmarastro.mykkumiserver.user.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -18,7 +19,7 @@ public class PostDto {
     private String category;
     private String subCategory;
     private Writer writer;
-    private String content;
+    private List<PostContentObject> content;
 
     public static PostDto of(Post post, User writer) {
         return PostDto.builder()

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostImageDto.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostImageDto.java
@@ -1,0 +1,13 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PostImageDto {
+
+    private String url;
+    private List<PinDto> pins;
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/ProductInfoDto.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/ProductInfoDto.java
@@ -1,0 +1,10 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProductInfoDto {
+
+    private String name;
+    private String url;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/RegisterPostRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/RegisterPostRequest.java
@@ -1,0 +1,13 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RegisterPostRequest {
+
+    private Long subCategoryId;
+    private String content;
+    private List<PostImageDto> images;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/RegisterPostResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/RegisterPostResponse.java
@@ -1,0 +1,17 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RegisterPostResponse {
+
+    private Long postId;
+
+    public static RegisterPostResponse of(Long postId) {
+        return RegisterPostResponse.builder()
+                .postId(postId)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/richtext/PostContentHashtagText.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/richtext/PostContentHashtagText.java
@@ -1,0 +1,18 @@
+package com.swmarastro.mykkumiserver.post.richtext;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class PostContentHashtagText extends PostContentObject {
+
+    private String color;
+    private String url;
+
+    public PostContentHashtagText(String text, String color, String url) {
+        super(text);
+        this.color = color;
+        this.url = url+text.substring(1);
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/richtext/PostContentObject.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/richtext/PostContentObject.java
@@ -1,0 +1,24 @@
+package com.swmarastro.mykkumiserver.post.richtext;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = PostContentHashtagText.class, name = "hashtag"),
+        @JsonSubTypes.Type(value = PostContentPlainText.class, name = "plain")
+})
+public abstract class PostContentObject {
+
+    protected String text;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/richtext/PostContentPlainText.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/richtext/PostContentPlainText.java
@@ -1,0 +1,11 @@
+package com.swmarastro.mykkumiserver.post.richtext;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class PostContentPlainText extends PostContentObject {
+
+    public PostContentPlainText(String text) {
+        super(text);
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/richtext/RichTextUtils.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/richtext/RichTextUtils.java
@@ -56,7 +56,7 @@ public class RichTextUtils {
         for (String token : tokens) {
             PostContentObject text;
             if (token.startsWith("#")) {
-                text = new PostContentHashtagText(token, POST_CONTENT_HASHTAG_COLOR, POST_HASHTAG_URL_PREFIX); //이 줄 작성 중이야
+                text = new PostContentHashtagText(token, POST_CONTENT_HASHTAG_COLOR, POST_HASHTAG_URL_PREFIX);
             } else {
                 text = new PostContentPlainText(token);
             }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/richtext/RichTextUtils.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/richtext/RichTextUtils.java
@@ -1,0 +1,68 @@
+package com.swmarastro.mykkumiserver.post.richtext;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@RequiredArgsConstructor
+public class RichTextUtils {
+
+    private static final String POST_CONTENT_HASHTAG_COLOR = "#0062FF";
+    private static final String POST_HASHTAG_URL_PREFIX = "mykkumi://search?hashtag=";
+
+    /**
+     * 문자열에서 plain text와 hashtag를 구분하여 잘라주는 메서드
+     */
+    public static List<String> extractPlainTextAndHashtags(String input) {
+        List<String> result = new ArrayList<>();
+
+        // 정규 표현식 패턴 정의
+        Pattern hashtagPattern = Pattern.compile("#\\S+");
+        Matcher matcher = hashtagPattern.matcher(input);
+
+        int lastIndex = 0;
+        while (matcher.find()) {
+            // 해시태그 이전의 일반 텍스트 부분 추출
+            if (matcher.start() > lastIndex) {
+                String plainText = input.substring(lastIndex, matcher.start());
+                result.add(plainText);
+            }
+
+            // 해시태그 부분 추출
+            String hashtagText = matcher.group();
+            result.add(hashtagText);
+
+            lastIndex = matcher.end();
+        }
+
+        // 마지막 해시태그 이후의 일반 텍스트 부분 추출
+        if (lastIndex < input.length()) {
+            String plainText = input.substring(lastIndex);
+            result.add(plainText);
+        }
+
+        return result;
+    }
+
+    /**
+     * 포스트 본문 일반 문자열 -> rich text 변환
+     */
+    public static List<PostContentObject> makePostContentStringToRichText(List<String> tokens) {
+
+        List<PostContentObject> richTexts = new ArrayList<>();
+        for (String token : tokens) {
+            PostContentObject text;
+            if (token.startsWith("#")) {
+                text = new PostContentHashtagText(token, POST_CONTENT_HASHTAG_COLOR, POST_HASHTAG_URL_PREFIX); //이 줄 작성 중이야
+            } else {
+                text = new PostContentPlainText(token);
+            }
+            richTexts.add(text);
+        }
+        return richTexts;
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
@@ -76,6 +76,19 @@ public class PostService {
         return savedPost.getId();
     }
 
+    public void deletePost(User user, Long postId) {
+        //본인의 포스트인지, 이미 삭제된 포스트는 아닌지 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_VALUE, "존재하지 않는 게시글입니다.", "해당 id의 게시글이 존재하지 않습니다."));
+        if(post.getUser()!=user)
+            throw new CommonException(ErrorCode.ACCESS_DENIED, "본인이 작성한 게시글만 삭제 가능합니다.", "삭제 권한이 없습니다. 본인이 작성한 게시글만 삭제 가능합니다.");
+        if(post.getIsDeleted())
+            throw new CommonException(ErrorCode.INVALID_VALUE, "존재하지 않는 게시글입니다.", "해당 id의 게시글이 존재하지 않습니다.");
+
+        //소프트 딜리트
+        post.deletePost();
+    }
+
     private PostLatestCursor getCursorFromBase64String(String encodedCursor) {
         if(encodedCursor==null || encodedCursor.isEmpty())
             return PostLatestCursor.of(LocalDateTime.now(), Long.MAX_VALUE);

--- a/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
@@ -1,25 +1,36 @@
 package com.swmarastro.mykkumiserver.post.service;
 
+import com.swmarastro.mykkumiserver.category.CategoryService;
+import com.swmarastro.mykkumiserver.category.domain.SubCategory;
 import com.swmarastro.mykkumiserver.global.exception.CommonException;
 import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import com.swmarastro.mykkumiserver.global.util.Base64Utils;
 import com.swmarastro.mykkumiserver.post.PostLatestCursor;
 import com.swmarastro.mykkumiserver.post.PostRepository;
+import com.swmarastro.mykkumiserver.post.domain.Pin;
 import com.swmarastro.mykkumiserver.post.domain.Post;
-import com.swmarastro.mykkumiserver.post.dto.PostDto;
-import com.swmarastro.mykkumiserver.post.dto.PostListResponse;
+import com.swmarastro.mykkumiserver.post.domain.PostImage;
+import com.swmarastro.mykkumiserver.post.dto.*;
+import com.swmarastro.mykkumiserver.post.richtext.PostContentObject;
+import com.swmarastro.mykkumiserver.post.richtext.RichTextUtils;
+import com.swmarastro.mykkumiserver.product.Product;
+import com.swmarastro.mykkumiserver.user.User;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PostService {
 
     private final PostRepository postRepository;
+    private final CategoryService categoryService;
 
     //TODO 이름에 최신순이라고 알려줘야할것 같다. 고민해보고 이름 고치기
     public PostListResponse getInfiniteScrollPosts(String encodedCursor, Integer limit) {
@@ -30,7 +41,6 @@ public class PostService {
         //TODO Cursor 인터페이스 하나 놓고 상속해서 커스텀하여 사용할 수도 있을 것 같다. 추후 구조 수정
         PostLatestCursor cursor = getCursorFromBase64String(encodedCursor);
         List<PostDto> posts = getPostsByCursorAndLimit(cursor, limit + 1);
-
         if (posts.size() < limit + 1) { //다음에 조회할 내용 없음
             return PostListResponse.end(posts);
         }
@@ -38,6 +48,32 @@ public class PostService {
         Long lastId = getLastIdFromPostList(posts);
         PostLatestCursor nextCursor = PostLatestCursor.of(cursor.getStartedAt(), lastId);
         return PostListResponse.of(posts, Base64Utils.encode(nextCursor));
+    }
+
+    public Long registerPost(User user, Long subCategoryId, String content, List<PostImageDto> images) {
+        //content -> rich text로 변환
+        List<String> contentTexts = RichTextUtils.extractPlainTextAndHashtags(content);
+        List<PostContentObject> postContentObjects = RichTextUtils.makePostContentStringToRichText(contentTexts);
+        SubCategory subCategory = categoryService.getSubCategoryById(subCategoryId);
+
+        List<PostImage> postImages = new ArrayList<>();
+        Long order=1L;
+        for (PostImageDto postImageDto : images) {
+            PostImage postImage = PostImage.of(postImageDto.getUrl(), order++);
+            List<Pin> pins = postImageDto.getPins().stream()
+                    .map(pinDto -> {
+                        Product product = Product.of(pinDto.getProductInfo().getName(), pinDto.getProductInfo().getUrl());
+                        return Pin.of(postImage, product, pinDto.getPositionX(), pinDto.getPositionY());
+                    })
+                    .collect(Collectors.toList());
+            postImage.addPins(pins);
+            postImages.add(postImage);
+        }
+
+        Post post = Post.of(postContentObjects, user, subCategory, postImages);
+        Post savedPost = postRepository.save(post);
+
+        return savedPost.getId();
     }
 
     private PostLatestCursor getCursorFromBase64String(String encodedCursor) {

--- a/src/main/java/com/swmarastro/mykkumiserver/product/Product.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/product/Product.java
@@ -1,0 +1,28 @@
+package com.swmarastro.mykkumiserver.product;
+
+import com.swmarastro.mykkumiserver.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private Long id;
+
+    private String productName;
+    private String productUrl;
+
+    public static Product of(String productName, String productUrl) {
+        return Product.builder()
+                .productName(productName)
+                .productUrl(productUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/product/ProductRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/product/ProductRepository.java
@@ -1,0 +1,6 @@
+package com.swmarastro.mykkumiserver.product;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/user/User.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/User.java
@@ -2,11 +2,9 @@ package com.swmarastro.mykkumiserver.user;
 
 import com.swmarastro.mykkumiserver.auth.OAuthProvider;
 import com.swmarastro.mykkumiserver.category.domain.UserSubCategory;
+import com.swmarastro.mykkumiserver.global.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
@@ -15,9 +13,9 @@ import java.util.UUID;
 @Getter
 @Entity
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class User {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 구현내용
### 1. plain text -> rich text
포스트 본문을 rich text로 만들기로 했습니다. 일반 string으로 본문이 들어오면, rich text로 변환하도록 했습니다.
```
동해물과 백두산이 마르고 닳도록 #하느님 이 보우하사 우리나라 만세 #무궁화 #삼천리 화려강산
```

```json
{
    "postContent":[
        {
	    "type": "plain",
            "text":"동해물과 백두산이 마르고 닳도록 "
        },
        {
	    "type": "hashtag",
            "text":"#하느님",
            "color":"#0062FF",
            "linkUrl":"mykkumi://search?query=하느님"
        },
        {
            "type": "plain",
            "text":" 이 보우하사 우리나라 만세"
        },
        {
            "type": "hashtag",
            "text":"#무궁화",
            "color":"#0062FF",
            "linkUrl":"mykkumi://search?query=무궁화"
        },
        {
	    "type": "hashtag",
            "text":"#삼천리",
            "color":"#0062FF",
            "linkUrl":"mykkumi://search?query=삼천리"
        },
        {
            "type": "plain",
            "text":"화려강산"
        }
    ]
}
```

### 2. 포스트 등록
포스트를 등록하는 api를 만들었습니다.
포스트 하나를 저장하기 위해 pin, post_image 등 여러 테이블에 정보가 저장됩니다. 처음에는 post 테이블에만 데이터가 저장되는 문제가 있었는데 아래와 같은 코드를 추가하여 해결했습니다. 
```java
cascade = CascadeType.ALL, orphanRemoval = true
```

### 3. 포스트 삭제
포스트를 삭제하는 api를 만들었습니다. 실제로 완전히 삭제되는 것은 아니고, isDeleted 컬럼을 둬서 소프트 딜리트되도록 했습니다.
바로 완전히 삭제하기보다는 후에 용량이 너무 커져 문제가 생긴다면 그 때 필요없는 데이터를 지워줄 생각입니다.

## 고민사항
### 1. rich text를 어떻게 저장할 것인지
mysql에 json을 그대로 저장할 수 있다는 것을 알게되어, json 형태 그대로 저장해줬습니다.
처음에는 문자열만 분리해서 저장해두고 font color와 같이 중복되는 부분들은 조회 시 만들어서 응답해줄까 생각을 했습니다.
하지만 서비스 특성상 조회가 많을 것이라 모든 요청마다 본문을 만들고 있다면 속도가 매우 느려지고 부하가 심할 것 같았습니다.
그래서 그냥 저장공간을 조금 더 쓰기로 하고 응답할 형태 그대로 포스트 작성 시 한번만 만들어서 넣어주었습니다.

### 2. BaseEntity 생성
BaseEntity를 생성하여 DB에 생기는 모든 테이블에 달아주었습니다.
매번 엔티티 생성 시마다 createdAt, updatedAt을 따로 써주지 않아 편리하고, 각 데이터들이 언제 생성되고 수정되었는지 쉽게 파악할 수 있을 것이라 기대합니다.
```java
@CreatedDate
private LocalDateTime createdAt;
@LastModifiedDate
private LocalDateTime updatedAt;
```
