### PR TITLE
KKUMI-62 user info update refactor

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/global/util/AwsS3Utils.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/util/AwsS3Utils.java
@@ -8,6 +8,7 @@ import com.swmarastro.mykkumiserver.global.config.S3properties;
 import com.swmarastro.mykkumiserver.global.exception.CommonException;
 import com.swmarastro.mykkumiserver.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class AwsS3Utils {
 
     private final AmazonS3 amazonS3;
@@ -52,6 +54,18 @@ public class AwsS3Utils {
         calendar.setTime(new Date());
         calendar.add(Calendar.MINUTE, 10); //10분간 유효함
         return amazonS3.generatePresignedUrl(bucketName, filePath, calendar.getTime(), HttpMethod.PUT).toString();
+    }
+
+    /**
+     * S3에서 이미지 삭제
+     */
+    public void deleteImageByUrl(String url) {
+        try {
+            String objectKey = getObjectKeyFromUrl(url);
+            amazonS3.deleteObject(s3properties.getBucket(), objectKey);
+        } catch (Exception e) {
+            log.info("이미지 삭제 중 에러 발생 "+e.getMessage());
+        }
     }
 
     public Boolean isValidUrl(String url, String hashCode) {

--- a/src/main/java/com/swmarastro/mykkumiserver/user/ProfileImageService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/ProfileImageService.java
@@ -1,0 +1,25 @@
+package com.swmarastro.mykkumiserver.user;
+
+import com.swmarastro.mykkumiserver.global.config.S3properties;
+import com.swmarastro.mykkumiserver.global.util.AwsS3Utils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+    private final AwsS3Utils awsS3Utils;
+    private final S3properties s3properties;
+
+    public String generatePostImagePreSignedUrl(String extension) {
+        String filePath = s3properties.getProfileImagePath() +
+                UUID.randomUUID() +
+                "." +
+                extension;
+        return awsS3Utils.generatePreSignedUrl(filePath, s3properties.getBucket());
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
@@ -3,6 +3,7 @@ package com.swmarastro.mykkumiserver.user;
 import com.swmarastro.mykkumiserver.auth.annotation.Login;
 import com.swmarastro.mykkumiserver.auth.annotation.RequiresLogin;
 import com.swmarastro.mykkumiserver.user.dto.MeResponse;
+import com.swmarastro.mykkumiserver.user.dto.ProfileImagePreSignedUrlResponse;
 import com.swmarastro.mykkumiserver.user.dto.UpdateUserRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final ProfileImageService profileImageService;
 
     @RequiresLogin
     @GetMapping("/users/me")
@@ -25,9 +27,17 @@ public class UserController {
 
     @RequiresLogin
     @PatchMapping("/users")
-    public ResponseEntity<MeResponse> updateUser(@Login User loginUser, @Valid @ModelAttribute UpdateUserRequest updateUserRequest) {
+    public ResponseEntity<MeResponse> updateUser(@Login User loginUser, @Valid @RequestBody UpdateUserRequest updateUserRequest) {
         User user = userService.updateUser(loginUser, updateUserRequest);
         MeResponse meResponse = MeResponse.of(user);
         return ResponseEntity.ok(meResponse);
+    }
+
+    @RequiresLogin
+    @GetMapping("/profileImage/preSignedUrl")
+    public ResponseEntity<ProfileImagePreSignedUrlResponse> getProfileImagePresignedUrl(@RequestParam String extension) {
+        String url = profileImageService.generatePostImagePreSignedUrl(extension);
+        ProfileImagePreSignedUrlResponse response = ProfileImagePreSignedUrlResponse.of(url);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
@@ -55,21 +55,24 @@ public class UserService {
     public User updateUser(User user, UpdateUserRequest updateUserRequest) {
         String nickname = updateUserRequest.getNickname();
         String introduction = updateUserRequest.getIntroduction();
-        String imageUrl = updateUserRequest.getProfileImage();
+        String profileImageUrl = updateUserRequest.getProfileImage();
         List<Long> categoryIds = updateUserRequest.getCategoryIds();
-
-        System.out.println(nickname+" "+introduction+" "+imageUrl);
 
         //중복된 닉네임일 때
         if (nickname != null && isNicknameExists(nickname)) {
             throw new CommonException(ErrorCode.DUPLICATE_VALUE, "이미 사용 중인 닉네임입니다.", "이미 사용 중인 닉네임입니다.");
         }
 
+        //프로필 이미지 이미 존재 시, 기존 이미지 삭제
+        if(profileImageUrl != null && user.getProfileImage()!=null) {
+            awsS3Utils.deleteImageByUrl(user.getProfileImage());
+        }
+
         //유저가 선택한 카테고리 update
         UserSubCategory userSubCategory = userSubCategoryRepository.findByUser(user);
         userSubCategory.updateSubCategory(categoryIds);
 
-        user.updateUser(nickname, introduction, imageUrl);
+        user.updateUser(nickname, introduction, profileImageUrl);
         return user;
     }
 

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserService.java
@@ -55,8 +55,10 @@ public class UserService {
     public User updateUser(User user, UpdateUserRequest updateUserRequest) {
         String nickname = updateUserRequest.getNickname();
         String introduction = updateUserRequest.getIntroduction();
-        String imageUrl = null;
+        String imageUrl = updateUserRequest.getProfileImage();
         List<Long> categoryIds = updateUserRequest.getCategoryIds();
+
+        System.out.println(nickname+" "+introduction+" "+imageUrl);
 
         //중복된 닉네임일 때
         if (nickname != null && isNicknameExists(nickname)) {
@@ -66,11 +68,6 @@ public class UserService {
         //유저가 선택한 카테고리 update
         UserSubCategory userSubCategory = userSubCategoryRepository.findByUser(user);
         userSubCategory.updateSubCategory(categoryIds);
-
-        //프로필 이미지 S3 업로드
-        if (updateUserRequest.getProfileImage() != null) {
-            imageUrl = uploadProfileImage(updateUserRequest.getProfileImage());
-        }
 
         user.updateUser(nickname, introduction, imageUrl);
         return user;

--- a/src/main/java/com/swmarastro/mykkumiserver/user/dto/ProfileImagePreSignedUrlResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/dto/ProfileImagePreSignedUrlResponse.java
@@ -1,0 +1,17 @@
+package com.swmarastro.mykkumiserver.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProfileImagePreSignedUrlResponse {
+
+    private String url;
+
+    public static ProfileImagePreSignedUrlResponse of(String url) {
+        return ProfileImagePreSignedUrlResponse.builder()
+                .url(url)
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/dto/UpdateUserRequest.java
@@ -16,7 +16,7 @@ public class UpdateUserRequest {
     @Pattern(regexp = "^[a-zA-Z0-9._\\-가-힣ㄱ-ㅎㅏ-ㅣ]+$", message = "닉네임은 숫자, 알파벳, '.', '_', '-', 한글만 포함할 수 있습니다.")
     @Size(min = 3, max = 16, message = "닉네임은 3자 이상 16자 이하이어야 합니다.")
     private String nickname;
-    private MultipartFile profileImage;
+    private String profileImage;
     private String introduction;
     private List<Long> categoryIds = new ArrayList<>();
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/dto/UpdateUserRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
## 구현내용
### 1. 유저 프로필 이미지 presignedUrl로 업로드
유저 프로필 이미지를 presignedUrl로 업로드하도록 변경했습니다.
기존에는 multipart로 업로드 했는데, 이미지 파일이 서버를 거쳐야 했습니다. 또한, 프로필 이미지 외에 카테고리 등 여러 정보를 함께 담아야 하는데 프론트에서 정보를 입력할 때 문제가 발생한다는 이야기를 들었습니다. 그래서 이미지를 string으로 프론트에서 보내줄 수 있도록 presignedUrl로 변경했습니다.

### 2. 유저 프로필 이미지 업데이트 시 기존 이미지 삭제
마이꾸미에서는 인스타그램과 같이 기존의 프로필 이미지는 다시 볼 수 없습니다. 한번 변경한 프로필 이미지는 다시 사용할 일이 없어 s3 저장공간만 차지하는 것 같아, 프로필 이미지 업데이트 시 기존의 이미지를 삭제하도록 했습니다.