### PR TITLE
KKUMI-102 presigned url과 함께 cdn url 내려주기

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostController.java
@@ -35,8 +35,7 @@ public class PostController {
     @RequiresLogin
     @GetMapping("/posts/preSignedUrl")
     public ResponseEntity<PostImagePreSignedUrlResponse> getPostImagePreSignedUrl(@RequestParam String extension) {
-        String url = postImageService.generatePostImagePreSignedUrl(extension);
-        PostImagePreSignedUrlResponse postImagePreSignedUrlResponse = PostImagePreSignedUrlResponse.of(url);
+        PostImagePreSignedUrlResponse postImagePreSignedUrlResponse = postImageService.generatePostImagePreSignedUrl(extension);
         return ResponseEntity.ok(postImagePreSignedUrlResponse);
     }
 

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostImagePreSignedUrlResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostImagePreSignedUrlResponse.java
@@ -7,11 +7,13 @@ import lombok.Getter;
 @Getter
 public class PostImagePreSignedUrlResponse {
 
-    private String url;
+    private String presignedUrl;
+    private String cdnUrl;
 
-    public static PostImagePreSignedUrlResponse of(String url) {
+    public static PostImagePreSignedUrlResponse of(String presignedUrl, String cdnUrl) {
         return PostImagePreSignedUrlResponse.builder()
-                .url(url)
+                .presignedUrl(presignedUrl)
+                .cdnUrl(cdnUrl)
                 .build();
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/service/PostImageService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/service/PostImageService.java
@@ -2,6 +2,7 @@ package com.swmarastro.mykkumiserver.post.service;
 
 import com.swmarastro.mykkumiserver.global.config.S3properties;
 import com.swmarastro.mykkumiserver.global.util.AwsS3Utils;
+import com.swmarastro.mykkumiserver.post.dto.PostImagePreSignedUrlResponse;
 import com.swmarastro.mykkumiserver.post.dto.ValidatePostImageUrlRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,13 +16,17 @@ public class PostImageService {
     private final AwsS3Utils awsS3Utils;
     private final S3properties s3properties;
 
-    public String generatePostImagePreSignedUrl(String extension) {
+    public PostImagePreSignedUrlResponse generatePostImagePreSignedUrl(String extension) {
         String filePath = s3properties.getPostImagePath() +
                 UUID.randomUUID() +
                 "." +
                 extension;
-        return awsS3Utils.generatePreSignedUrl(filePath, s3properties.getBucket());
+        String presignedUrl = awsS3Utils.generatePreSignedUrl(filePath, s3properties.getBucket());
+        String cdnUrl = s3properties.getCdnUrlPrefix()+filePath.substring("image/".length());
+        return PostImagePreSignedUrlResponse.of(presignedUrl, cdnUrl);
     }
+
+
 
     public Boolean validatePostImageUrl(ValidatePostImageUrlRequest request) {
         return awsS3Utils.isValidUrl(request.getUrl(), request.getHashCode());


### PR DESCRIPTION
프론트에서 사진 업로드 후 편집하거나 하는데에 필요하다고 해서 cdn url도 함께 내려줌

## 구현내용
### 1. cdn url도 함께 내려주기
presigned url을 발급할때 cdn url도 함께 내려줍니다.
프론트에서 이미지 업로드 후 포스트 작성완료 전까지 사용할 일이 있다고 해서 올린후 바로 조회할 수 있도록 했습니다.