### PR TITLE
KKUMI-102 [FEAT] #53 프로필 이미지 presigned url + cdn url

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/user/ProfileImageService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/ProfileImageService.java
@@ -2,6 +2,7 @@ package com.swmarastro.mykkumiserver.user;
 
 import com.swmarastro.mykkumiserver.global.config.S3properties;
 import com.swmarastro.mykkumiserver.global.util.AwsS3Utils;
+import com.swmarastro.mykkumiserver.user.dto.ProfileImagePreSignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,12 +15,14 @@ public class ProfileImageService {
     private final AwsS3Utils awsS3Utils;
     private final S3properties s3properties;
 
-    public String generatePostImagePreSignedUrl(String extension) {
+    public ProfileImagePreSignedUrlResponse generatePostImagePreSignedUrl(String extension) {
         String filePath = s3properties.getProfileImagePath() +
                 UUID.randomUUID() +
                 "." +
                 extension;
-        return awsS3Utils.generatePreSignedUrl(filePath, s3properties.getBucket());
+        String presignedUrl = awsS3Utils.generatePreSignedUrl(filePath, s3properties.getBucket());
+        String cdnUrl = s3properties.getCdnUrlPrefix() + filePath.substring("image/".length());
+        return ProfileImagePreSignedUrlResponse.of(presignedUrl, cdnUrl);
     }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/UserController.java
@@ -36,8 +36,7 @@ public class UserController {
     @RequiresLogin(checkNickname = false)
     @GetMapping("/profileImage/preSignedUrl")
     public ResponseEntity<ProfileImagePreSignedUrlResponse> getProfileImagePresignedUrl(@RequestParam String extension) {
-        String url = profileImageService.generatePostImagePreSignedUrl(extension);
-        ProfileImagePreSignedUrlResponse response = ProfileImagePreSignedUrlResponse.of(url);
+        ProfileImagePreSignedUrlResponse response = profileImageService.generatePostImagePreSignedUrl(extension);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/user/dto/ProfileImagePreSignedUrlResponse.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/user/dto/ProfileImagePreSignedUrlResponse.java
@@ -7,11 +7,13 @@ import lombok.Getter;
 @Getter
 public class ProfileImagePreSignedUrlResponse {
 
-    private String url;
+    private String presignedUrl;
+    private String cdnUrl;
 
-    public static ProfileImagePreSignedUrlResponse of(String url) {
+    public static ProfileImagePreSignedUrlResponse of(String presignedUrl, String cdnUrl) {
         return ProfileImagePreSignedUrlResponse.builder()
-                .url(url)
+                .presignedUrl(presignedUrl)
+                .cdnUrl(cdnUrl)
                 .build();
     }
 }


### PR DESCRIPTION
프론트에서 사진 업로드 후 편집하거나 하는데에 필요하다고 해서 cdn url도 함께 내려줍니다.
```프로필 이미지``` 부분이 빠져서 추가합니다.

구현내용
1. cdn url도 함께 내려주기
presigned url을 발급할때 cdn url도 함께 내려줍니다.
프론트에서 이미지 업로드 후 포스트 작성완료 전까지 사용할 일이 있다고 해서 올린후 바로 조회할 수 있도록 했습니다.
