### PR TITLE
Kkumi 113/feature/#66/refactoring post read

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     // json-simple for JSON processing
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
+    //MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/MykkumiServerApplication.java
@@ -3,9 +3,13 @@ package com.swmarastro.mykkumiserver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableMongoRepositories(basePackages = "com.swmarastro.mykkumiserver")
 public class MykkumiServerApplication {
     public static void main(String[] args) {
         SpringApplication.run(MykkumiServerApplication.class, args);

--- a/src/main/java/com/swmarastro/mykkumiserver/global/config/AwsProperties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/config/AwsProperties.java
@@ -1,0 +1,19 @@
+package com.swmarastro.mykkumiserver.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class AwsProperties {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/global/config/S3Config.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/config/S3Config.java
@@ -13,16 +13,16 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class S3Config {
 
-    private final S3properties s3properties;
+    private final AwsProperties awsProperties;
 
     @Bean
     public AmazonS3 AmazonS3Client() {
-        AWSCredentials credentials = new BasicAWSCredentials(s3properties.getAccessKey(), s3properties.getSecretKey());
+        AWSCredentials credentials = new BasicAWSCredentials(awsProperties.getAccessKey(), awsProperties.getSecretKey());
 
         return AmazonS3ClientBuilder
                 .standard()
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(s3properties.getRegion())
+                .withRegion(awsProperties.getRegion())
                 .build();
     }
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/global/config/S3properties.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/global/config/S3properties.java
@@ -9,14 +9,6 @@ import org.springframework.stereotype.Component;
 @Getter
 @Component
 public class S3properties {
-    @Value("${cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String secretKey;
-
-    @Value("${cloud.aws.region.static}")
-    private String region;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostMongoRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostMongoRepository.java
@@ -1,0 +1,7 @@
+package com.swmarastro.mykkumiserver.post;
+
+import com.swmarastro.mykkumiserver.post.domain.PostView;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PostMongoRepository extends MongoRepository<PostView, Long> {
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/PostRepository.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/PostRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -14,9 +13,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.id < :lastId AND p.isDeleted = false ORDER BY p.id DESC")
     List<Post> findLatestOrderByIdDesc(Long lastId, Pageable pageable);
 
+    @Query("SELECT p.id FROM Post p WHERE p.id < :lastId AND p.isDeleted = false ORDER BY p.id DESC")
+    List<Long> findIdLatestOrderByIdDesc(Long lastId, Pageable pageable);
+
     @Query("SELECT p FROM Post p JOIN FETCH p.user " +
             "WHERE p.id < :lastId AND p.isDeleted = false AND p.subCategory.id IN :categoryIds " +
             "ORDER BY p.id DESC")
     List<Post> findLatestOrderByIdDescInSubCategory(Long lastId, List<Long> categoryIds, Pageable pageable);
+
+    @Query("SELECT p.id FROM Post p " +
+            "WHERE p.id < :lastId AND p.isDeleted = false AND p.subCategory.id IN :categoryIds " +
+            "ORDER BY p.id DESC")
+    List<Long> findIdLatestOrderByIdDescInSubcategory(Long lastId, List<Long> categoryIds, Pageable pageable);
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/domain/PostView.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/domain/PostView.java
@@ -1,0 +1,46 @@
+package com.swmarastro.mykkumiserver.post.domain;
+
+import com.swmarastro.mykkumiserver.category.domain.Category;
+import com.swmarastro.mykkumiserver.post.dto.PostImageDto;
+import com.swmarastro.mykkumiserver.post.richtext.PostContentObject;
+import com.swmarastro.mykkumiserver.user.User;
+import com.swmarastro.mykkumiserver.post.dto.Writer;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Document(collection="postview")
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostView {
+
+    @Id
+    private Long id;
+    private String category;
+    private String subCategory;
+    private Writer writer;
+    private List<PostContentObject> content;
+    private List<PostImageDto> images;
+
+    public static PostView of(Post post, Category category, User writer, List<PostImageDto> images) {
+        Writer postWriter = Writer.builder()
+                .uuid(writer.getUuid().toString())
+                .profileImage(writer.getProfileImage())
+                .nickname(writer.getNickname())
+                .build();
+
+        return PostView.builder()
+                .id(post.getId())
+                .category(category.getName())
+                .subCategory(post.getSubCategory().getName())
+                .writer(postWriter)
+                .content(post.getContent())
+                .images(images)
+                .build();
+    }
+
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostDto.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/PostDto.java
@@ -1,9 +1,11 @@
 package com.swmarastro.mykkumiserver.post.dto;
 
 import com.swmarastro.mykkumiserver.post.domain.Post;
+import com.swmarastro.mykkumiserver.post.domain.PostView;
 import com.swmarastro.mykkumiserver.post.richtext.PostContentObject;
 import com.swmarastro.mykkumiserver.user.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 @Builder
 public class PostDto {
 
+    @Id
     private Long id;
     private String category;
     private String subCategory;
@@ -38,20 +41,15 @@ public class PostDto {
                 .build();
     }
 
-    @Getter
-    @Builder
-    static class Writer {
-        private String uuid;
-        private String profileImage;
-        private String nickname;
-
-        static public Writer of(User user) {
-            return Writer.builder()
-                    .uuid(user.getUuid().toString())
-                    .profileImage(user.getProfileImage())
-                    .nickname(user.getNickname())
-                    .build();
-        }
+    public static PostDto of(PostView postView) {
+        return PostDto.builder()
+                .id(postView.getId())
+                .category(postView.getCategory())
+                .subCategory(postView.getSubCategory())
+                .writer(postView.getWriter())
+                .content(postView.getContent())
+                .images(postView.getImages())
+                .build();
     }
 
 }

--- a/src/main/java/com/swmarastro/mykkumiserver/post/dto/Writer.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/dto/Writer.java
@@ -1,0 +1,21 @@
+package com.swmarastro.mykkumiserver.post.dto;
+
+import com.swmarastro.mykkumiserver.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Writer {
+    private String uuid;
+    private String profileImage;
+    private String nickname;
+
+    static public Writer of(User user) {
+        return Writer.builder()
+                .uuid(user.getUuid().toString())
+                .profileImage(user.getProfileImage())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/event/PostCreatedEvent.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/event/PostCreatedEvent.java
@@ -1,0 +1,20 @@
+package com.swmarastro.mykkumiserver.post.event;
+
+import com.swmarastro.mykkumiserver.category.domain.Category;
+import com.swmarastro.mykkumiserver.post.domain.Post;
+import com.swmarastro.mykkumiserver.post.dto.PostImageDto;
+import com.swmarastro.mykkumiserver.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PostCreatedEvent {
+
+    private final Post post;
+    private final Category category;
+    private final User writer;
+    private final List<PostImageDto> images;
+}

--- a/src/main/java/com/swmarastro/mykkumiserver/post/event/listener/PostEventListener.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/event/listener/PostEventListener.java
@@ -1,0 +1,28 @@
+package com.swmarastro.mykkumiserver.post.event.listener;
+
+import com.swmarastro.mykkumiserver.post.PostMongoRepository;
+import com.swmarastro.mykkumiserver.post.domain.PostView;
+import com.swmarastro.mykkumiserver.post.event.PostCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostEventListener {
+
+    private final PostMongoRepository postMongoRepository;
+
+    @Async
+    @TransactionalEventListener
+    public void savePostView(PostCreatedEvent event) {
+        //mongoDB에 저장하기
+        PostView postView = PostView.of(event.getPost(), event.getCategory(), event.getWriter(), event.getImages());
+        postMongoRepository.save(postView);
+
+        log.info("[EVENT-PostCreatedEvent] Saved post view, Post ID : "+event.getPost().getId());
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,7 @@
+spring:
+  config:
+    import:
+      - 'aws-secretsmanager:local/mykkumi/mysql'
+      - 'aws-secretsmanager:dev/mykkumi/s3'
+      - 'aws-secretsmanager:dev/mykkumi/jwt'
+      - 'aws-secretsmanager:dev/mykkumi/oauth'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,9 +7,13 @@ spring:
     username: ${db_username}
     password: ${db_password}
 
+  data:
+    mongodb:
+      uri: ${mongodb_uri}
+
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 구현내용
### 1.  MongoDB에 포스트 저장
#### 문제상황
기존 방식에서는 포스트 하나를 조회할 때 MySQL의 테이블을 10개 이상 조회했습니다.
K6로 테스트한 결과, 100명이 30초간 1초마다 요청을 보낼때, 응답을 받기까지 평균 2.83초가 걸림을 확인했습니다.
좋아요, 댓글 등 업데이트될 기능들을 생각하면 테이블은 계속 늘어나며 속도가 더 느려질 것이라고 생각했습니다.
![스크린샷 2024-10-02 오후 3 38 48](https://github.com/user-attachments/assets/a1df2f4b-7339-4a66-bd05-8bd17d9355c7)

#### 해결방안
속도 개선을 위해 MongoDB를 추가 도입하기로 했습니다.
포스트 생성시, MySQL에 정보 저장 이후 PostCreatedEvent 를 발생시켜줬습니다.
이후 EventListener를 통해 PostCreatedEvent를 처리하며 MongoDB에 정보를 저장해줬습니다.
MongoDB에는 포스트가 조회될 모양을 미리 만들어 Json 형식으로 저장했습니다.
조회 시 여러 테이블 정보를 모아 Json 모양을 손수 만들 필요가 없이, key 로 조회하여 바로 내려줄 수 있도록 했습니다.

### 2. MongoDB에서 포스트 조회
포스트를 조회할 때에는, 아래와 같은 순서로 구현했습니다.
1. MySQL에서 조회할 포스트의 ID만 조회
2. MongoDB에서 Post ID로 JSON 조회

#### 결과
그 결과, K6 테스트 결과 100명이 30초간 1초마다 요청을 보낼때, 응답을 받기까지 평균 17ms로 속도가 160배 이상 향상된 것을 확인했습니다.
![스크린샷 2024-10-02 오후 3 43 52](https://github.com/user-attachments/assets/79502d7b-843b-4fe5-87e9-6a5fc78dbd93)