### PR TITLE
KKUMI-113 [FIX] #66 lazy 로딩으로 설정된 데이터 미리 로딩

### DIFF
--- a/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
+++ b/src/main/java/com/swmarastro/mykkumiserver/post/service/PostService.java
@@ -23,6 +23,7 @@ import com.swmarastro.mykkumiserver.user.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -98,6 +99,9 @@ public class PostService {
 
         Post post = Post.of(postContentObjects, user, subCategory, postImages);
         Post savedPost = postRepository.save(post); //mysql 저장 완료
+
+        Hibernate.initialize(post.getSubCategory());
+        Hibernate.initialize(post.getSubCategory().getCategory());
 
         eventPublisher.publishEvent(new PostCreatedEvent(post, subCategory.getCategory(), user, images));
 


### PR DESCRIPTION
## 구현내용
### 1. 비동기 작업 전 데이터 초기화
비동기처리로 진행되어 category 데이터가 없는 문제 dev서버에서 발생
비동기 작업을 실행하기 전에 관련 데이터를 모두 초기화해 두면 세션이 종료된 이후에도 안전하게 데이터를 사용할 수 있다고 하여 추가